### PR TITLE
Add MachO Encryption Info as well as a simple gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,75 @@
+
+# Created by https://www.gitignore.io/api/osx,cmake,xcode
+
+### CMake ###
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+
+### OSX ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+# End of https://www.gitignore.io/api/osx,cmake,xcode

--- a/api/python/MachO/CMakeLists.txt
+++ b/api/python/MachO/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LIEF_PYTHON_MACHO_SRC
   "${CMAKE_CURRENT_LIST_DIR}/objects/pyBinary.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/objects/pyLoadCommand.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/objects/pySegmentCommand.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/objects/pyEncryptionInfoCommand.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/objects/pyHeader.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/objects/pySection.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/objects/pyParser.cpp"
@@ -13,6 +14,3 @@ set(LIEF_PYTHON_MACHO_SRC
 
 target_include_directories(pyLIEF PUBLIC "${CMAKE_CURRENT_LIST_DIR}")
 target_sources(pyLIEF PRIVATE "${LIEF_PYTHON_MACHO_SRC}")
-
-
-

--- a/api/python/MachO/objects/pyEncryptionInfoCommand.cpp
+++ b/api/python/MachO/objects/pyEncryptionInfoCommand.cpp
@@ -36,24 +36,21 @@ void init_MachO_EncryptionInfoCommand_class(py::module& m) {
     .def_property("cryptoff",
         static_cast<getter_t<uint32_t>>(&EncryptionInfoCommand::crypt_offset),
         static_cast<setter_t<uint32_t>>(&EncryptionInfoCommand::crypt_offset),
-        "Crypto chunk offset",
-        py::return_value_policy::reference_internal)
+        "Crypto chunk offset")
 
     .def_property("cryptsize",
         static_cast<getter_t<uint32_t>>(&EncryptionInfoCommand::crypt_size),
         static_cast<setter_t<uint32_t>>(&EncryptionInfoCommand::crypt_size),
-        "Crypto chunk size",
-        py::return_value_policy::reference_internal)
+        "Crypto chunk size")
     .def_property("cryptid",
         static_cast<getter_t<uint32_t>>(&EncryptionInfoCommand::crypt_id),
         static_cast<setter_t<uint32_t>>(&EncryptionInfoCommand::crypt_id),
-        "Crypto ID",
-        py::return_value_policy::reference_internal)
+        "Crypto ID")
     .def("__eq__", &EncryptionInfoCommand::operator==)
     .def("__ne__", &EncryptionInfoCommand::operator!=)
     .def("__hash__",
-        [] (const EncryptionInfoCommand& dylib_command) {
-          return LIEF::Hash::hash(dylib_command);
+        [] (const EncryptionInfoCommand& encryption_info_command) {
+          return LIEF::Hash::hash(encryption_info_command);
         })
 
 

--- a/api/python/MachO/objects/pyEncryptionInfoCommand.cpp
+++ b/api/python/MachO/objects/pyEncryptionInfoCommand.cpp
@@ -1,0 +1,69 @@
+/* Copyright 2017 R. Thomas
+ * Copyright 2017 Quarkslab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <algorithm>
+
+#include <string>
+#include <sstream>
+
+#include "LIEF/visitors/Hash.hpp"
+#include "LIEF/MachO/EncryptionInfoCommand.hpp"
+
+#include "pyMachO.hpp"
+
+template<class T>
+using getter_t = T (EncryptionInfoCommand::*)(void) const;
+
+template<class T>
+using setter_t = void (EncryptionInfoCommand::*)(T);
+
+
+void init_MachO_EncryptionInfoCommand_class(py::module& m) {
+
+  py::class_<EncryptionInfoCommand, LoadCommand>(m, "EncryptionInfoCommand")
+    .def_property("cryptoff",
+        static_cast<getter_t<uint32_t>>(&EncryptionInfoCommand::crypt_offset),
+        static_cast<setter_t<uint32_t>>(&EncryptionInfoCommand::crypt_offset),
+        "Crypto chunk offset",
+        py::return_value_policy::reference_internal)
+
+    .def_property("cryptsize",
+        static_cast<getter_t<uint32_t>>(&EncryptionInfoCommand::crypt_size),
+        static_cast<setter_t<uint32_t>>(&EncryptionInfoCommand::crypt_size),
+        "Crypto chunk size",
+        py::return_value_policy::reference_internal)
+    .def_property("cryptid",
+        static_cast<getter_t<uint32_t>>(&EncryptionInfoCommand::crypt_id),
+        static_cast<setter_t<uint32_t>>(&EncryptionInfoCommand::crypt_id),
+        "Crypto ID",
+        py::return_value_policy::reference_internal)
+    .def("__eq__", &EncryptionInfoCommand::operator==)
+    .def("__ne__", &EncryptionInfoCommand::operator!=)
+    .def("__hash__",
+        [] (const EncryptionInfoCommand& dylib_command) {
+          return LIEF::Hash::hash(dylib_command);
+        })
+
+
+    .def("__str__",
+        [] (const EncryptionInfoCommand& command)
+        {
+          std::ostringstream stream;
+          stream << command;
+          std::string str = stream.str();
+          return str;
+        });
+
+}

--- a/api/python/MachO/objects/pyEncryptionInfoCommand.cpp
+++ b/api/python/MachO/objects/pyEncryptionInfoCommand.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017 R. Thomas
+/* Copyright 2017 Zhang
  * Copyright 2017 Quarkslab
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,6 +46,10 @@ void init_MachO_EncryptionInfoCommand_class(py::module& m) {
         static_cast<getter_t<uint32_t>>(&EncryptionInfoCommand::crypt_id),
         static_cast<setter_t<uint32_t>>(&EncryptionInfoCommand::crypt_id),
         "Crypto ID")
+    .def_property("pad",
+        static_cast<getter_t<uint32_t>>(&EncryptionInfoCommand::pad),
+        static_cast<setter_t<uint32_t>>(&EncryptionInfoCommand::pad),
+        "Padding")
     .def("__eq__", &EncryptionInfoCommand::operator==)
     .def("__ne__", &EncryptionInfoCommand::operator!=)
     .def("__hash__",

--- a/api/python/MachO/pyMachO.cpp
+++ b/api/python/MachO/pyMachO.cpp
@@ -34,6 +34,7 @@ void init_MachO_module(py::module& m) {
   init_MachO_SegmentCommand_class(LIEF_MachO_module);
   init_MachO_Section_class(LIEF_MachO_module);
   init_MachO_Symbol_class(LIEF_MachO_module);
+  init_MachO_EncryptionInfoCommand_class(LIEF_MachO_module);
 
 
   // Enums

--- a/api/python/MachO/pyMachO.hpp
+++ b/api/python/MachO/pyMachO.hpp
@@ -34,6 +34,7 @@ void init_MachO_DylibCommand_class(py::module&);
 void init_MachO_SegmentCommand_class(py::module&);
 void init_MachO_Section_class(py::module&);
 void init_MachO_Symbol_class(py::module&);
+void init_MachO_EncryptionInfoCommand_class(py::module&);
 
 // Enums
 void init_MachO_Structures_enum(py::module&);

--- a/include/LIEF/MachO/EncryptionInfoCommand.hpp
+++ b/include/LIEF/MachO/EncryptionInfoCommand.hpp
@@ -1,4 +1,5 @@
 /* Copyright 2017 Zhang
+ * Copyright 2017 Quarkslab
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,16 +32,19 @@ class DLL_PUBLIC EncryptionInfoCommand : public LoadCommand {
   public:
     EncryptionInfoCommand(void);
     EncryptionInfoCommand(const encryption_info_command_32 *cmd);
+    EncryptionInfoCommand(const encryption_info_command_64 *cmd);
     EncryptionInfoCommand& operator=(const EncryptionInfoCommand& copy);
     EncryptionInfoCommand(const EncryptionInfoCommand& copy);
     virtual ~EncryptionInfoCommand(void);
     uint32_t crypt_offset(void) const;
     uint32_t crypt_size(void) const;
     uint32_t crypt_id(void) const;
+    uint32_t pad(void) const;
 
     void crypt_offset(uint32_t offset);
     void crypt_size(uint32_t sz);
     void crypt_id(uint32_t id);
+    void pad(uint32_t pd);
     virtual std::ostream& print(std::ostream& os) const override;
 
     virtual void accept(Visitor& visitor) const override;
@@ -51,6 +55,7 @@ class DLL_PUBLIC EncryptionInfoCommand : public LoadCommand {
     uint32_t crypt_offset_;
     uint32_t crypt_size_;
     uint32_t crypt_id_;
+    uint32_t pad_;
 };
 
 }

--- a/include/LIEF/MachO/EncryptionInfoCommand.hpp
+++ b/include/LIEF/MachO/EncryptionInfoCommand.hpp
@@ -1,0 +1,58 @@
+/* Copyright 2017 Zhang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIEF_MACHO_ENCRYPTION_INFO__H_
+#define LIEF_MACHO_ENCRYPTION_INFO__H_
+
+#include <iostream>
+#include <set>
+#include <string>
+
+#include "LIEF/visibility.h"
+#include "LIEF/MachO/Structures.hpp"
+#include "LIEF/MachO/LoadCommand.hpp"
+#include "LIEF/types.hpp"
+
+namespace LIEF {
+namespace MachO {
+
+class DLL_PUBLIC EncryptionInfoCommand : public LoadCommand {
+  public:
+    EncryptionInfoCommand(void);
+    EncryptionInfoCommand(const encryption_info_command_32 *cmd);
+    EncryptionInfoCommand& operator=(const EncryptionInfoCommand& copy);
+    EncryptionInfoCommand(const EncryptionInfoCommand& copy);
+    virtual ~EncryptionInfoCommand(void);
+    uint32_t crypt_offset(void) const;
+    uint32_t crypt_size(void) const;
+    uint32_t crypt_id(void) const;
+
+    void crypt_offset(uint32_t offset);
+    void crypt_size(uint32_t sz);
+    void crypt_id(uint32_t id);
+    virtual std::ostream& print(std::ostream& os) const override;
+
+    virtual void accept(Visitor& visitor) const override;
+
+    bool operator==(const EncryptionInfoCommand& rhs) const;
+    bool operator!=(const EncryptionInfoCommand& rhs) const;
+  private:
+    uint32_t crypt_offset_;
+    uint32_t crypt_size_;
+    uint32_t crypt_id_;
+};
+
+}
+}
+#endif

--- a/src/MachO/BinaryParser.cpp
+++ b/src/MachO/BinaryParser.cpp
@@ -28,6 +28,7 @@
 
 
 #include "LIEF/MachO/BinaryParser.hpp"
+#include "LIEF/MachO/EncryptionInfoCommand.hpp"
 #include "BinaryParser.tcc"
 
 #include "LIEF/MachO/utils.hpp"

--- a/src/MachO/BinaryParser.tcc
+++ b/src/MachO/BinaryParser.tcc
@@ -297,7 +297,15 @@ void BinaryParser::parse_load_commands(void) {
           load_command = new LoadCommand{command};
           break;
         }
-      case LOAD_COMMAND_TYPES::LC_ENCRYPTION_INFO_64:
+      case LOAD_COMMAND_TYPES::LC_ENCRYPTION_INFO_64:{
+          LOG(DEBUG) << "[+] Parsing LC_ENCRYPTION_INFO_64";
+          const encryption_info_command_64* cmd =
+            reinterpret_cast<const encryption_info_command_64*>(
+              this->stream_->read(loadcommands_offset, sizeof(encryption_info_command_64)));
+
+          load_command = new EncryptionInfoCommand{cmd};
+          break;
+        }
       case LOAD_COMMAND_TYPES::LC_ENCRYPTION_INFO:{
           LOG(DEBUG) << "[+] Parsing LC_ENCRYPTION_INFO";
           const encryption_info_command_32* cmd =

--- a/src/MachO/BinaryParser.tcc
+++ b/src/MachO/BinaryParser.tcc
@@ -297,7 +297,16 @@ void BinaryParser::parse_load_commands(void) {
           load_command = new LoadCommand{command};
           break;
         }
+      case LOAD_COMMAND_TYPES::LC_ENCRYPTION_INFO_64:
+      case LOAD_COMMAND_TYPES::LC_ENCRYPTION_INFO:{
+          LOG(DEBUG) << "[+] Parsing LC_ENCRYPTION_INFO";
+          const encryption_info_command_32* cmd =
+            reinterpret_cast<const encryption_info_command_32*>(
+              this->stream_->read(loadcommands_offset, sizeof(encryption_info_command_32)));
 
+          load_command = new EncryptionInfoCommand{cmd};
+          break;
+        }
       default:
         {
           LOG(WARNING) << "Command '" << to_string(static_cast<LOAD_COMMAND_TYPES>(command->cmd))

--- a/src/MachO/CMakeLists.txt
+++ b/src/MachO/CMakeLists.txt
@@ -15,7 +15,9 @@ set(LIEF_MACHO_SRC
   "${CMAKE_CURRENT_LIST_DIR}/SymbolCommand.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/MainCommand.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/DylibCommand.cpp"
-  "${CMAKE_CURRENT_LIST_DIR}/DylinkerCommand.cpp")
+  "${CMAKE_CURRENT_LIST_DIR}/DylinkerCommand.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/EncryptionInfoCommand.cpp"
+  )
 
 
 target_sources(LIB_LIEF_STATIC PRIVATE ${LIEF_MACHO_SRC})

--- a/src/MachO/EncryptionInfoCommand.cpp
+++ b/src/MachO/EncryptionInfoCommand.cpp
@@ -1,0 +1,82 @@
+/* Copyright 2017 Zhang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "LIEF/visitors/Hash.hpp"
+
+#include "LIEF/MachO/EncryptionInfoCommand.hpp"
+
+namespace LIEF {
+namespace MachO {
+
+EncryptionInfoCommand::EncryptionInfoCommand(void) = default;
+EncryptionInfoCommand& EncryptionInfoCommand::operator=(const EncryptionInfoCommand&) = default;
+EncryptionInfoCommand::EncryptionInfoCommand(const EncryptionInfoCommand&) = default;
+EncryptionInfoCommand::~EncryptionInfoCommand(void) = default;
+
+EncryptionInfoCommand::EncryptionInfoCommand(const encryption_info_command_32 *command) :
+  crypt_offset_{command->cryptoff},
+  crypt_size_{command->cryptsize},
+  crypt_id_{command->cryptid}
+{
+  this->command_ = static_cast<LOAD_COMMAND_TYPES>(command->cmd);
+  this->size_    = command->cmdsize;
+}
+
+void EncryptionInfoCommand::accept(Visitor& visitor) const {
+  LoadCommand::accept(visitor);
+  visitor.visit(this->crypt_id());
+  visitor.visit(this->crypt_size());
+  visitor.visit(this->crypt_offset());
+}
+uint32_t EncryptionInfoCommand::crypt_offset(void) const{
+  return this->crypt_offset_;
+}
+uint32_t EncryptionInfoCommand::crypt_size(void) const{
+  return this->crypt_size_;
+}
+uint32_t EncryptionInfoCommand::crypt_id(void) const{
+  return this->crypt_id_;
+}
+
+void EncryptionInfoCommand::crypt_offset(uint32_t offset){
+  this->crypt_offset_=offset;
+}
+void EncryptionInfoCommand::crypt_size(uint32_t sz){
+  this->crypt_size_=sz;
+}
+void EncryptionInfoCommand::crypt_id(uint32_t id){
+  this->crypt_id_=id;
+}
+
+bool EncryptionInfoCommand::operator==(const EncryptionInfoCommand& rhs) const {
+  size_t hash_lhs = Hash::hash(*this);
+  size_t hash_rhs = Hash::hash(rhs);
+  return hash_lhs == hash_rhs;
+}
+
+bool EncryptionInfoCommand::operator!=(const EncryptionInfoCommand& rhs) const {
+  return not (*this == rhs);
+}
+
+std::ostream& EncryptionInfoCommand::print(std::ostream& os) const {
+  LoadCommand::print(os);
+  os << "CryptID    : " << this->crypt_id() << std::endl;
+  os << "CryptSize    : " << this->crypt_size() << std::endl;
+  os << "CryptOffset    : " << this->crypt_offset() << std::endl;
+  return os;
+}
+
+
+}
+}

--- a/src/MachO/EncryptionInfoCommand.cpp
+++ b/src/MachO/EncryptionInfoCommand.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2017 Zhang
+ * Copyright 2017 Quarkslab
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +32,16 @@ EncryptionInfoCommand::EncryptionInfoCommand(const encryption_info_command_32 *c
 {
         this->command_ = static_cast<LOAD_COMMAND_TYPES>(command->cmd);
         this->size_    = command->cmdsize;
+        this->pad_=0;
+}
+EncryptionInfoCommand::EncryptionInfoCommand(const encryption_info_command_64 *command) :
+        crypt_offset_{command->cryptoff},
+        crypt_size_{command->cryptsize},
+        crypt_id_{command->cryptid},
+        pad_{command->pad}
+{
+        this->command_ = static_cast<LOAD_COMMAND_TYPES>(command->cmd);
+        this->size_    = command->cmdsize;
 }
 
 void EncryptionInfoCommand::accept(Visitor& visitor) const {
@@ -48,7 +59,9 @@ uint32_t EncryptionInfoCommand::crypt_size(void) const {
 uint32_t EncryptionInfoCommand::crypt_id(void) const {
         return this->crypt_id_;
 }
-
+uint32_t EncryptionInfoCommand::pad(void) const{
+        return this->pad_;
+}
 void EncryptionInfoCommand::crypt_offset(uint32_t offset){
         this->crypt_offset_ = offset;
 }
@@ -57,6 +70,9 @@ void EncryptionInfoCommand::crypt_size(uint32_t sz){
 }
 void EncryptionInfoCommand::crypt_id(uint32_t id){
         this->crypt_id_ = id;
+}
+void EncryptionInfoCommand::pad(uint32_t pd){
+        this->pad_=pd;
 }
 
 bool EncryptionInfoCommand::operator==(const EncryptionInfoCommand& rhs) const {

--- a/src/MachO/EncryptionInfoCommand.cpp
+++ b/src/MachO/EncryptionInfoCommand.cpp
@@ -25,56 +25,56 @@ EncryptionInfoCommand::EncryptionInfoCommand(const EncryptionInfoCommand&) = def
 EncryptionInfoCommand::~EncryptionInfoCommand(void) = default;
 
 EncryptionInfoCommand::EncryptionInfoCommand(const encryption_info_command_32 *command) :
-  crypt_offset_{command->cryptoff},
-  crypt_size_{command->cryptsize},
-  crypt_id_{command->cryptid}
+        crypt_offset_{command->cryptoff},
+        crypt_size_{command->cryptsize},
+        crypt_id_{command->cryptid}
 {
-  this->command_ = static_cast<LOAD_COMMAND_TYPES>(command->cmd);
-  this->size_    = command->cmdsize;
+        this->command_ = static_cast<LOAD_COMMAND_TYPES>(command->cmd);
+        this->size_    = command->cmdsize;
 }
 
 void EncryptionInfoCommand::accept(Visitor& visitor) const {
-  LoadCommand::accept(visitor);
-  visitor.visit(this->crypt_id());
-  visitor.visit(this->crypt_size());
-  visitor.visit(this->crypt_offset());
+        LoadCommand::accept(visitor);
+        visitor.visit(this->crypt_id());
+        visitor.visit(this->crypt_size());
+        visitor.visit(this->crypt_offset());
 }
-uint32_t EncryptionInfoCommand::crypt_offset(void) const{
-  return this->crypt_offset_;
+uint32_t EncryptionInfoCommand::crypt_offset(void) const {
+        return this->crypt_offset_;
 }
-uint32_t EncryptionInfoCommand::crypt_size(void) const{
-  return this->crypt_size_;
+uint32_t EncryptionInfoCommand::crypt_size(void) const {
+        return this->crypt_size_;
 }
-uint32_t EncryptionInfoCommand::crypt_id(void) const{
-  return this->crypt_id_;
+uint32_t EncryptionInfoCommand::crypt_id(void) const {
+        return this->crypt_id_;
 }
 
 void EncryptionInfoCommand::crypt_offset(uint32_t offset){
-  this->crypt_offset_=offset;
+        this->crypt_offset_ = offset;
 }
 void EncryptionInfoCommand::crypt_size(uint32_t sz){
-  this->crypt_size_=sz;
+        this->crypt_size_ = sz;
 }
 void EncryptionInfoCommand::crypt_id(uint32_t id){
-  this->crypt_id_=id;
+        this->crypt_id_ = id;
 }
 
 bool EncryptionInfoCommand::operator==(const EncryptionInfoCommand& rhs) const {
-  size_t hash_lhs = Hash::hash(*this);
-  size_t hash_rhs = Hash::hash(rhs);
-  return hash_lhs == hash_rhs;
+        size_t hash_lhs = Hash::hash(*this);
+        size_t hash_rhs = Hash::hash(rhs);
+        return hash_lhs == hash_rhs;
 }
 
 bool EncryptionInfoCommand::operator!=(const EncryptionInfoCommand& rhs) const {
-  return not (*this == rhs);
+        return not (*this == rhs);
 }
 
 std::ostream& EncryptionInfoCommand::print(std::ostream& os) const {
-  LoadCommand::print(os);
-  os << "CryptID    : " << this->crypt_id() << std::endl;
-  os << "CryptSize    : " << this->crypt_size() << std::endl;
-  os << "CryptOffset    : " << this->crypt_offset() << std::endl;
-  return os;
+        LoadCommand::print(os);
+        os << "CryptID    : " << this->crypt_id() << std::endl;
+        os << "CryptSize    : " << this->crypt_size() << std::endl;
+        os << "CryptOffset    : " << this->crypt_offset() << std::endl;
+        return os;
 }
 
 

--- a/src/MachO/EncryptionInfoCommand.cpp
+++ b/src/MachO/EncryptionInfoCommand.cpp
@@ -14,85 +14,78 @@
  * limitations under the License.
  */
 #include "LIEF/visitors/Hash.hpp"
-
 #include "LIEF/MachO/EncryptionInfoCommand.hpp"
 
 namespace LIEF {
 namespace MachO {
-
 EncryptionInfoCommand::EncryptionInfoCommand(void) = default;
-EncryptionInfoCommand& EncryptionInfoCommand::operator=(const EncryptionInfoCommand&) = default;
-EncryptionInfoCommand::EncryptionInfoCommand(const EncryptionInfoCommand&) = default;
+EncryptionInfoCommand & EncryptionInfoCommand::operator = (const EncryptionInfoCommand & ) = default;
+EncryptionInfoCommand::EncryptionInfoCommand(const EncryptionInfoCommand & ) = default;
 EncryptionInfoCommand::~EncryptionInfoCommand(void) = default;
-
-EncryptionInfoCommand::EncryptionInfoCommand(const encryption_info_command_32 *command) :
-        crypt_offset_{command->cryptoff},
-        crypt_size_{command->cryptsize},
-        crypt_id_{command->cryptid}
+EncryptionInfoCommand::EncryptionInfoCommand(const encryption_info_command_32 * command):
+    crypt_offset_ {command->cryptoff},
+    crypt_size_ {command->cryptsize},
+    crypt_id_ {command->cryptid}
 {
-        this->command_ = static_cast<LOAD_COMMAND_TYPES>(command->cmd);
-        this->size_    = command->cmdsize;
-        this->pad_=0;
+    this->command_ = static_cast < LOAD_COMMAND_TYPES > (command->cmd);
+    this->size_ = command->cmdsize;
+    this->pad_ = 0;
 }
-EncryptionInfoCommand::EncryptionInfoCommand(const encryption_info_command_64 *command) :
-        crypt_offset_{command->cryptoff},
-        crypt_size_{command->cryptsize},
-        crypt_id_{command->cryptid},
-        pad_{command->pad}
+EncryptionInfoCommand::EncryptionInfoCommand(const encryption_info_command_64 * command):
+    crypt_offset_ {command->cryptoff},
+    crypt_size_ {command->cryptsize},
+    crypt_id_ {command->cryptid},
+    pad_ {command->pad}
 {
-        this->command_ = static_cast<LOAD_COMMAND_TYPES>(command->cmd);
-        this->size_    = command->cmdsize;
+    this->command_ = static_cast < LOAD_COMMAND_TYPES > (command->cmd);
+    this->size_ = command->cmdsize;
 }
 
-void EncryptionInfoCommand::accept(Visitor& visitor) const {
-        LoadCommand::accept(visitor);
-        visitor.visit(this->crypt_id());
-        visitor.visit(this->crypt_size());
-        visitor.visit(this->crypt_offset());
+void EncryptionInfoCommand::accept(Visitor & visitor) const {
+    LoadCommand::accept(visitor);
+    visitor.visit(this->crypt_id());
+    visitor.visit(this->crypt_size());
+    visitor.visit(this->crypt_offset());
 }
 uint32_t EncryptionInfoCommand::crypt_offset(void) const {
-        return this->crypt_offset_;
+    return this->crypt_offset_;
 }
 uint32_t EncryptionInfoCommand::crypt_size(void) const {
-        return this->crypt_size_;
+    return this->crypt_size_;
 }
 uint32_t EncryptionInfoCommand::crypt_id(void) const {
-        return this->crypt_id_;
+    return this->crypt_id_;
 }
-uint32_t EncryptionInfoCommand::pad(void) const{
-        return this->pad_;
+uint32_t EncryptionInfoCommand::pad(void) const {
+    return this->pad_;
 }
-void EncryptionInfoCommand::crypt_offset(uint32_t offset){
-        this->crypt_offset_ = offset;
+void EncryptionInfoCommand::crypt_offset(uint32_t offset) {
+    this->crypt_offset_ = offset;
 }
-void EncryptionInfoCommand::crypt_size(uint32_t sz){
-        this->crypt_size_ = sz;
+void EncryptionInfoCommand::crypt_size(uint32_t sz) {
+    this->crypt_size_ = sz;
 }
-void EncryptionInfoCommand::crypt_id(uint32_t id){
-        this->crypt_id_ = id;
+void EncryptionInfoCommand::crypt_id(uint32_t id) {
+    this->crypt_id_ = id;
 }
-void EncryptionInfoCommand::pad(uint32_t pd){
-        this->pad_=pd;
+void EncryptionInfoCommand::pad(uint32_t pd) {
+    this->pad_ = pd;
 }
-
-bool EncryptionInfoCommand::operator==(const EncryptionInfoCommand& rhs) const {
-        size_t hash_lhs = Hash::hash(*this);
-        size_t hash_rhs = Hash::hash(rhs);
-        return hash_lhs == hash_rhs;
+bool EncryptionInfoCommand::operator == (const EncryptionInfoCommand & rhs) const {
+    size_t hash_lhs = Hash::hash( * this);
+    size_t hash_rhs = Hash::hash(rhs);
+    return hash_lhs == hash_rhs;
 }
-
-bool EncryptionInfoCommand::operator!=(const EncryptionInfoCommand& rhs) const {
-        return not (*this == rhs);
+bool EncryptionInfoCommand::operator != (const EncryptionInfoCommand & rhs) const {
+    return not( * this == rhs);
 }
-
-std::ostream& EncryptionInfoCommand::print(std::ostream& os) const {
-        LoadCommand::print(os);
-        os << "CryptID    : " << this->crypt_id() << std::endl;
-        os << "CryptSize    : " << this->crypt_size() << std::endl;
-        os << "CryptOffset    : " << this->crypt_offset() << std::endl;
-        return os;
+std::ostream & EncryptionInfoCommand::print(std::ostream & os) const {
+    LoadCommand::print(os);
+    os << "CryptID    : " << this->crypt_id() << std::endl;
+    os << "CryptSize    : " << this->crypt_size() << std::endl;
+    os << "CryptOffset    : " << this->crypt_offset() << std::endl;
+    return os;
 }
 
-
-}
-}
+}//namespace MachO
+}//namesapce LIEF


### PR DESCRIPTION
I've tested this on a Python2 binding with an ARM MachO. yielding the following:

```
[python] python                                                                                           master  ✭ ✱
Python 2.7.13 (default, Jan 16 2017, 16:04:23) 
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import lief
>>> binary = lief.parse("/Users/Naville/Downloads/UZApp.")
Command 'DYLD_INFO_ONLY' not parsed
Command 'VERSION_MIN_IPHONEOS' not parsed
Command 'SOURCE_VERSION' not parsed
Command 'RPATH' not parsed
Command 'DATA_IN_CODE' not parsed
>>> print unicode(binary)
.... Omitted
Command : ENCRYPTION_INFO
Offset  : 9f8
Size    : 14
CryptID    : 0
CryptSize    : 59c000
CryptOffset    : 4000
.... Omitted
```
which is identical to the values given by other similar tools.

That being said, I'm a C++ noob so there might be bugs/design defectives/build issues/etc.