### PR TITLE
Retain the sections that read data out of bounds

### DIFF
--- a/src/PE/Parser.cpp
+++ b/src/PE/Parser.cpp
@@ -131,15 +131,13 @@ void Parser::build_sections(void) {
         ptr_to_rawdata,
         ptr_to_rawdata + sections[i].SizeOfRawData
       };
-
-      this->binary_->sections_.push_back(section);
     } catch (const std::bad_alloc& e) {
       LOG(WARNING) << "Section " << section->name() << " corrupted: " << e.what();
-      delete section;
     } catch (const read_out_of_bound& e) {
       LOG(WARNING) << "Section " << section->name() << " corrupted: " << e.what();
-      delete section;
     }
+
+    this->binary_->sections_.push_back(section);
   }
 }
 


### PR DESCRIPTION
When reading sections that point out of raw data, or are too large, it is still useful to retain their section information from the section table and leave their content empty. This pull request removes the delete for these cases and moves the _push_back_ to outside the content setting block.