### PR TITLE
Fix Incorrect Overlay

### DIFF
--- a/include/LIEF/BinaryStream/VectorStream.hpp
+++ b/include/LIEF/BinaryStream/VectorStream.hpp
@@ -35,6 +35,7 @@ class VectorStream : public BinaryStream {
 
   private:
     std::vector<uint8_t> binary_;
+    uint64_t size_;
 };
 
 

--- a/src/BinaryStream/VectorStream.cpp
+++ b/src/BinaryStream/VectorStream.cpp
@@ -32,11 +32,11 @@ VectorStream::VectorStream(const std::string& filename) {
     binary.unsetf(std::ios::skipws);
     binary.seekg(0, std::ios::end);
     assert(binary.tellg() > 0);
-    const uint64_t filesize = static_cast<uint64_t>(binary.tellg());
+    this->size_ = static_cast<uint64_t>(binary.tellg());
     binary.seekg(0, std::ios::beg);
 
     // reserve capacity
-    this->binary_.resize(filesize + 30, 0);
+    this->binary_.resize(this->size_ + 30, 0);
     std::copy(
       std::istreambuf_iterator<char>(binary),
       std::istreambuf_iterator<char>(),
@@ -51,25 +51,27 @@ VectorStream::VectorStream(const std::string& filename) {
 
 VectorStream::VectorStream(const std::vector<uint8_t>& data):
   binary_(data)
-{}
+{
+  this->size_ = data.size();
+}
 
 
 uint64_t VectorStream::size(void) const {
-  return this->binary_.size();
+  return this->size_;
 }
 
 
 const void* VectorStream::read(uint64_t offset, uint64_t size) const {
 
-  if (offset > this->binary_.size() or (offset + size) > this->binary_.size()) {
+  if (offset > this->size_ or (offset + size) > this->size_) {
     LOG(DEBUG) << "Offset: " << std::hex << offset << std::endl;
     LOG(DEBUG) << "Size:   " << std::hex << size   << std::endl;
 
-    if (offset > this->binary_.size()) {
+    if (offset > this->size_) {
       throw LIEF::read_out_of_bound(offset);
     }
 
-    if ((offset + size) > this->binary_.size()) {
+    if ((offset + size) > this->size_) {
       throw LIEF::read_out_of_bound(offset, size);
     }
   }
@@ -80,7 +82,7 @@ const void* VectorStream::read(uint64_t offset, uint64_t size) const {
 
 const char* VectorStream::read_string(uint64_t offset) const {
 
-  if (offset > this->binary_.size()) {
+  if (offset > this->size_) {
     throw LIEF::read_out_of_bound(offset);
   }
   return reinterpret_cast<const char*>(this->binary_.data() + offset);

--- a/src/PE/Parser.cpp
+++ b/src/PE/Parser.cpp
@@ -131,15 +131,13 @@ void Parser::build_sections(void) {
         ptr_to_rawdata,
         ptr_to_rawdata + sections[i].SizeOfRawData
       };
-
-      this->binary_->sections_.push_back(section);
     } catch (const std::bad_alloc& e) {
       LOG(WARNING) << "Section " << section->name() << " corrupted: " << e.what();
-      delete section;
     } catch (const read_out_of_bound& e) {
       LOG(WARNING) << "Section " << section->name() << " corrupted: " << e.what();
-      delete section;
     }
+
+    this->binary_->sections_.push_back(section);
   }
 }
 


### PR DESCRIPTION
PE overlay's are calculated using the VectorStream's size, which used the _binary__'s vector size. Because the vector is over allocated, all PE's (except those that were truncated) had an overlay of 30 NULL bytes. This pull request modifies how the VectorStream's size is returned, as well as checks that overlays exist and returns an empty vector if it doesn't.