### PR TITLE
Parse the MachO LC_RPATH command

### DIFF
--- a/api/python/MachO/CMakeLists.txt
+++ b/api/python/MachO/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIEF_PYTHON_MACHO_SRC
   "${CMAKE_CURRENT_LIST_DIR}/objects/pyBindingInfo.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/objects/pyExportInfo.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/objects/pyThreadCommand.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/objects/pyRPathCommand.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/objects/pyParserConfig.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/pyMachOStructures.cpp"
 )

--- a/api/python/MachO/objects/pyRPathCommand.cpp
+++ b/api/python/MachO/objects/pyRPathCommand.cpp
@@ -1,0 +1,61 @@
+/* Copyright 2017 J.Rieck (based on R. Thomas's work)
+ * Copyright 2017 Quarkslab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <algorithm>
+
+#include <string>
+#include <sstream>
+
+#include "LIEF/visitors/Hash.hpp"
+#include "LIEF/MachO/RPathCommand.hpp"
+
+#include "pyMachO.hpp"
+
+template<class T>
+using getter_t = T (RPathCommand::*)(void) const;
+
+template<class T>
+using setter_t = void (RPathCommand::*)(T);
+
+
+void init_MachO_RPathCommand_class(py::module& m) {
+
+  py::class_<RPathCommand, LoadCommand>(m, "RPathCommand")
+
+    .def_property("path",
+        static_cast<getter_t<const std::string&>>(&RPathCommand::path),
+        static_cast<setter_t<const std::string&>>(&RPathCommand::path),
+        "@rpath path",
+        py::return_value_policy::reference_internal)
+
+
+    .def("__eq__", &RPathCommand::operator==)
+    .def("__ne__", &RPathCommand::operator!=)
+    .def("__hash__",
+        [] (const RPathCommand& rpath_command) {
+          return LIEF::Hash::hash(rpath_command);
+        })
+
+
+    .def("__str__",
+        [] (const RPathCommand& rpath_command)
+        {
+          std::ostringstream stream;
+          stream << rpath_command;
+          std::string str = stream.str();
+          return str;
+        });
+
+}

--- a/api/python/MachO/pyMachO.cpp
+++ b/api/python/MachO/pyMachO.cpp
@@ -47,7 +47,7 @@ void init_MachO_module(py::module& m) {
   init_MachO_BindingInfo_class(LIEF_MachO_module);
   init_MachO_ExportInfo_class(LIEF_MachO_module);
   init_MachO_ThreadCommand_class(LIEF_MachO_module);
-
+  init_MachO_RPathCommand_class(LIEF_MachO_module);
 
   // Enums
   init_MachO_Structures_enum(LIEF_MachO_module);

--- a/api/python/MachO/pyMachO.hpp
+++ b/api/python/MachO/pyMachO.hpp
@@ -49,6 +49,7 @@ void init_MachO_RelocationDyld_class(py::module&);
 void init_MachO_BindingInfo_class(py::module&);
 void init_MachO_ExportInfo_class(py::module&);
 void init_MachO_ThreadCommand_class(py::module&);
+void init_MachO_RPathCommand_class(py::module&);
 
 // Enums
 void init_MachO_Structures_enum(py::module&);

--- a/doc/sphinx/api/cpp/macho.rst
+++ b/doc/sphinx/api/cpp/macho.rst
@@ -217,6 +217,14 @@ Thread Command
 
 ----------
 
+RPath Command
+*************
+
+.. doxygenclass:: LIEF::MachO::RPathCommand
+   :project: lief
+
+----------
+
 Utilities
 *********
 

--- a/doc/sphinx/api/python/macho.rst
+++ b/doc/sphinx/api/python/macho.rst
@@ -251,6 +251,17 @@ Thread Command
 
 ----------
 
+RPath Command
+*************
+
+.. autoclass:: lief.MachO.RPathCommand
+   :members:
+   :inherited-members:
+   :undoc-members:
+
+----------
+
+
 Enums
 *****
 

--- a/include/LIEF/MachO/Binary.hpp
+++ b/include/LIEF/MachO/Binary.hpp
@@ -40,6 +40,7 @@
 #include "LIEF/MachO/SourceVersion.hpp"
 #include "LIEF/MachO/VersionMin.hpp"
 #include "LIEF/MachO/ThreadCommand.hpp"
+#include "LIEF/MachO/RPathCommand.hpp"
 
 namespace LIEF {
 namespace MachO {

--- a/include/LIEF/MachO/RPathCommand.hpp
+++ b/include/LIEF/MachO/RPathCommand.hpp
@@ -1,0 +1,55 @@
+/* Copyright 2017 J. Rieck (based on R. Thomas's work)
+ * Copyright 2017 Quarkslab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIEF_MACHO_RPATH_COMMAND_H_
+#define LIEF_MACHO_RPATH_COMMAND_H_
+#include <string>
+#include <iostream>
+
+#include "LIEF/visibility.h"
+#include "LIEF/types.hpp"
+
+#include "LIEF/MachO/LoadCommand.hpp"
+
+namespace LIEF {
+namespace MachO {
+
+class DLL_PUBLIC RPathCommand : public LoadCommand {
+  public:
+    RPathCommand(void);
+    RPathCommand(const rpath_command *rpathCmd);
+
+    RPathCommand& operator=(const RPathCommand& copy);
+    RPathCommand(const RPathCommand& copy);
+
+    virtual ~RPathCommand(void);
+
+    const std::string& path(void) const;
+    void   path(const std::string& path);
+
+    bool operator==(const RPathCommand& rhs) const;
+    bool operator!=(const RPathCommand& rhs) const;
+
+    virtual void accept(Visitor& visitor) const override;
+
+    virtual std::ostream& print(std::ostream& os) const override;
+
+  private:
+    std::string path_;
+};
+
+}
+}
+#endif

--- a/include/LIEF/Visitor.hpp
+++ b/include/LIEF/Visitor.hpp
@@ -146,6 +146,7 @@ class DynamicSymbolCommand;
 class DylinkerCommand;
 class DylibCommand;
 class ThreadCommand;
+class RPathCommand;
 
 class Symbol;
 class Relocation;
@@ -481,6 +482,9 @@ class DLL_PUBLIC Visitor {
 
   //! @brief Method to visit a LIEF::MachO::ThreadCommand
   virtual void visit(const MachO::ThreadCommand& thread);
+
+  //! @brief Method to visit a LIEF::MachO::RPathCommand
+  virtual void visit(const MachO::RPathCommand& rpath_command);
 #endif
 
   template<class T>

--- a/src/MachO/BinaryParser.tcc
+++ b/src/MachO/BinaryParser.tcc
@@ -158,6 +158,23 @@ void BinaryParser::parse_load_commands(void) {
           break;
         }
 
+      // =============
+      // RPath Command
+      // =============
+      case LOAD_COMMAND_TYPES::LC_RPATH:
+        {
+          const rpath_command* cmd =
+            reinterpret_cast<const rpath_command*>(
+              this->stream_->read(loadcommands_offset, sizeof(rpath_command)));
+
+          load_command = std::unique_ptr<RPathCommand>{new RPathCommand{cmd}};
+          const uint32_t str_path_offset = cmd->path;
+          std::string path = this->stream_->get_string(loadcommands_offset + str_path_offset);
+
+          dynamic_cast<RPathCommand*>(load_command.get())->path(path);
+          break;
+        }
+
       // ====
       // UUID
       // ====

--- a/src/MachO/CMakeLists.txt
+++ b/src/MachO/CMakeLists.txt
@@ -45,6 +45,7 @@ set(LIEF_MACHO_SRC
   "${CMAKE_CURRENT_LIST_DIR}/BindingInfo.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/ExportInfo.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/ThreadCommand.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/RPathCommand.cpp"  
   "${CMAKE_CURRENT_LIST_DIR}/ParserConfig.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/Visitor.cpp"
 )
@@ -79,6 +80,7 @@ set(LIEF_MACHO_INCLUDE_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/include/LIEF/MachO/RelocationDyld.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/LIEF/MachO/BindingInfo.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/LIEF/MachO/ExportInfo.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/LIEF/MachO/RPathCommand.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/LIEF/MachO/ThreadCommand.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/include/LIEF/MachO/ParserConfig.hpp"
   )

--- a/src/MachO/RPathCommand.cpp
+++ b/src/MachO/RPathCommand.cpp
@@ -1,0 +1,71 @@
+/* Copyright 2017 J.Rieck (based on R. Thomas's work)
+ * Copyright 2017 Quarkslab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <numeric>
+#include <iomanip>
+
+#include "LIEF/visitors/Hash.hpp"
+
+#include "LIEF/MachO/RPathCommand.hpp"
+
+namespace LIEF {
+namespace MachO {
+
+RPathCommand::RPathCommand(void) = default;
+RPathCommand& RPathCommand::operator=(const RPathCommand&) = default;
+RPathCommand::RPathCommand(const RPathCommand&) = default;
+RPathCommand::~RPathCommand(void) = default;
+
+RPathCommand::RPathCommand(const rpath_command *rpathCmd) :
+  LoadCommand::LoadCommand{static_cast<LOAD_COMMAND_TYPES>(rpathCmd->cmd), rpathCmd->cmdsize}
+{
+}
+
+const std::string& RPathCommand::path(void) const {
+  return this->path_;
+}
+
+void RPathCommand::path(const std::string& path) {
+  this->path_ = path;
+}
+
+
+void RPathCommand::accept(Visitor& visitor) const {
+  LoadCommand::accept(visitor);
+  visitor.visit(this->path());
+}
+
+
+bool RPathCommand::operator==(const RPathCommand& rhs) const {
+  size_t hash_lhs = Hash::hash(*this);
+  size_t hash_rhs = Hash::hash(rhs);
+  return hash_lhs == hash_rhs;
+}
+
+bool RPathCommand::operator!=(const RPathCommand& rhs) const {
+  return not (*this == rhs);
+}
+
+
+std::ostream& RPathCommand::print(std::ostream& os) const {
+  LoadCommand::print(os);
+  os << std::left
+     << std::setw(10) << "Path: " << this->path();
+  return os;
+}
+
+
+}
+}

--- a/src/MachO/Visitor.cpp
+++ b/src/MachO/Visitor.cpp
@@ -93,4 +93,8 @@ void Visitor::visit(const MachO::ThreadCommand& thread) {
   thread.accept(*this);
 }
 
+void Visitor::visit(const MachO::RPathCommand& rpath_command) {
+  rpath_command.accept(*this);
+}
+
 }

--- a/tests/macho/macho_tests.py
+++ b/tests/macho/macho_tests.py
@@ -62,6 +62,11 @@ class TestMachO(TestCase):
         self.assertEqual(micromacho.thread_command.count, 16)
         self.assertEqual(micromacho.entrypoint, 0x68)
 
+    def test_rpath_cmd(self):
+        rpathmacho = lief.parse(get_sample('MachO/MachO64_x86-64_binary_rpathtest.bin'))
+        load_cmds = list(rpathmacho.commands)
+        rpath_cmd = load_cmds[-3]
+        self.assertEqual(rpath_cmd.path, "@executable_path/../lib")
 
     def test_relocations(self):
         helloworld = lief.parse(get_sample('MachO/MachO64_x86-64_object_HelloWorld64.o'))


### PR DESCRIPTION
This patch adds parsing for the LC_RPATH command. The LC_RPATH command is used to specify an additional root path where libraries can be found. Multiple LC_RPATH commands can be included in a single MachO file.

Unfortunately, none of the test binaries feature such a command. Therefore, I have not yet added a test, though I did test the functionality on my own.