### PR TITLE
Added FreeBSD references to solve install issues

### DIFF
--- a/api/python/setup.py.in
+++ b/api/python/setup.py.in
@@ -49,6 +49,7 @@ libpylief = {
         'Windows': "_pylief.pyd",
         'Darwin': "_pylief.so",
         'Linux': "_pylief.so",
+        'FreeBSD': "_pylief.so",
         }
 version_re = r"Version:\s+(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.?(.*)"
 if in_source_package:
@@ -72,6 +73,9 @@ def get_lief_platform_name():
         return "osx" if arch == 64 else "osx_x32"
     elif system == 'Linux':
         return "linux" if arch == 64 else "linux_x32"
+    elif system == 'FreeBSD':
+        return "freebsd" if arch == 64 else "freebsd_x32"
+
 
 
 class lief_sdist(sdist):


### PR DESCRIPTION
Added FreeBSD as possible target OS. Python3.6 install --user was throwing error about unknown OS. 
these fixes worked on my end.

performed the building according to the LIEF documentation

> $ git clone https://github.com/lief-project/LIEF.git
> $ cd LIEF
> $ mkdir build
> $ cd build
> $ cmake -DLIEF_PYTHON_API=on -DPYTHON_VERSION=3.6 -DCMAKE_BUILD_TYPE=Release ..
> $ cmake --build . --target LIB_LIEF_STATIC --config Release
> $ cmake --build . --target LIB_LIEF_SHARED --config Release # for the shared one
> $ cmake --build . --target pyLIEF --config Release

Manually copied both libs and include directory.
and installed the python modules to my personal (.local) site-packages with the suggested change.
