### PR TITLE
LoadConfigurationV5 doc fix

### DIFF
--- a/doc/sphinx/api/python/pe.rst
+++ b/doc/sphinx/api/python/pe.rst
@@ -466,7 +466,7 @@ Load Configuration V4
 Load Configuration V5
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: lief.PE.LoadConfigurationV4
+.. autoclass:: lief.PE.LoadConfigurationV5
   :members:
   :show-inheritance:
   :undoc-members:


### PR DESCRIPTION
Tiny documentation fix: LoadConfigurationV5 was showing the documentation for the LoadConfigurationV4 class.