### PR TITLE
Windows compilation support (fix missing -lws2_32)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,11 @@ else()
   add_library(LIB_LIEF_SHARED SHARED EXCLUDE_FROM_ALL ${LIBLIEF_SOURCE_FILES} ${LIEF_INCLUDE_FILES}) # Shared one
 endif()
 
+
+if(WINDOWS)
+  target_link_libraries(LIB_LIEF_SHARED ws2_32)
+endif()
+
 target_compile_definitions(LIB_LIEF_STATIC PRIVATE -DLIEF_STATIC)
 target_compile_definitions(LIB_LIEF_SHARED PRIVATE -DLIEF_EXPORTS)
 if (LIEF_SUPPORT_CXX14)


### PR DESCRIPTION
Adds 3 lines into the main CMakeLists.txt so that the user can provide `-DWINDOWS=1` to cmake to include the necessary dependency ws2_32 in the build process.

See: https://github.com/ARMmbed/mbedtls/issues/231

The mbedtls makefile isn't used, therefore the dependency has to be added in the LIEF CMakeLists.