### PR TITLE
fixed inverted ENDIAN_LITTLE and _BIG values

### DIFF
--- a/include/LIEF/Abstract/enums.hpp
+++ b/include/LIEF/Abstract/enums.hpp
@@ -69,8 +69,8 @@ enum MODES {
 
 enum ENDIANNESS {
   ENDIAN_NONE   = 0,
-  ENDIAN_BIG    = 1,
-  ENDIAN_LITTLE = 2,
+  ENDIAN_LITTLE = 1,
+  ENDIAN_BIG    = 2,
 };
 
 


### PR DESCRIPTION
Simple fix for inverted values between big and little endian designations in ELF headers