### PR TITLE
Add applies_to field to Relocation

### DIFF
--- a/api/python/ELF/objects/pyRelocation.cpp
+++ b/api/python/ELF/objects/pyRelocation.cpp
@@ -62,6 +62,15 @@ void init_ELF_Relocation_class(py::module& m) {
         "" RST_CLASS_REF(lief.ELF.Symbol) " associated with the relocation",
         py::return_value_policy::reference_internal)
 
+    .def_property_readonly("has_applies_to",
+        &Relocation::has_applies_to,
+        "``True`` if a this relocation identifies a " RST_CLASS_REF(lief.ELF.Section) " to be applied to")
+
+    .def_property_readonly("applies_to",
+        static_cast<Section& (Relocation::*)(void)>(&Relocation::applies_to),
+        "" RST_CLASS_REF(lief.ELF.Section) " to which the relocation applies",
+        py::return_value_policy::reference_internal)
+
     .def_property_readonly("is_rela",
       static_cast<getter_t<bool>>(&Relocation::is_rela),
       "``True`` if the relocation uses the :attr:`~lief.ELF.Relocation.addend` proprety")

--- a/include/LIEF/ELF/Parser.hpp
+++ b/include/LIEF/ELF/Parser.hpp
@@ -181,7 +181,7 @@ class LIEF_API Parser : public LIEF::Parser {
     //! use parse relocations by using LIEF::ELF::Segment. This method parse relocations
     //! that are not reachable through segments (For example Object file).
     template<typename ELF_T, typename REL_T>
-    void parse_section_relocations(uint64_t offset, uint64_t size);
+    void parse_section_relocations(uint64_t offset, uint64_t size, Section *applies_to=nullptr);
 
     //! @brief Parse SymbolVersionRequirement
     //!

--- a/include/LIEF/ELF/Relocation.hpp
+++ b/include/LIEF/ELF/Relocation.hpp
@@ -77,6 +77,10 @@ class LIEF_API Relocation : public LIEF::Relocation {
     Symbol&       symbol(void);
     const Symbol& symbol(void) const;
 
+    bool           has_applies_to(void) const;
+    Section&       applies_to(void);
+    const Section& applies_to(void) const;
+    
     //void address(uint64_t address);
     void addend(int64_t addend);
     void type(uint32_t type);
@@ -96,6 +100,7 @@ class LIEF_API Relocation : public LIEF::Relocation {
     Symbol*             symbol_;
     ARCH                architecture_;
     RELOCATION_PURPOSES purpose_;
+    Section*            applies_to_;
 };
 
 

--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -418,15 +418,15 @@ void Parser::parse_binary(void) {
   // Try to parse using sections
   if (this->binary_->relocations_.size() == 0) {
     for (const Section& section : this->binary_->sections()) {
+      uint64_t sh_info = section.information();
       try {
         if (section.type() == ELF_SECTION_TYPES::SHT_REL) {
           this->parse_section_relocations<ELF_T, typename ELF_T::Elf_Rel>(
-            section.file_offset(), section.size());
-
+            section.file_offset(), section.size(), this->binary_->sections_[sh_info]);
         }
         else if (section.type() == ELF_SECTION_TYPES::SHT_RELA) {
           this->parse_section_relocations<ELF_T, typename ELF_T::Elf_Rela>(
-            section.file_offset(), section.size());
+            section.file_offset(), section.size(), this->binary_->sections_[sh_info]);
         }
 
       } catch (const exception& e) {
@@ -1319,9 +1319,12 @@ void Parser::parse_pltgot_relocations(uint64_t offset, uint64_t size) {
 }
 
 template<typename ELF_T, typename REL_T>
-void Parser::parse_section_relocations(uint64_t offset, uint64_t size) {
-  static_assert(std::is_same<REL_T, typename ELF_T::Elf_Rel>::value or
-                std::is_same<REL_T, typename ELF_T::Elf_Rela>::value, "REL_T must be Elf_Rel or Elf_Rela");
+void Parser::parse_section_relocations(uint64_t offset, uint64_t size, Section *applies_to) {
+  using Elf_Rel = typename ELF_T::Elf_Rel;
+  using Elf_Rela = typename ELF_T::Elf_Rela;
+
+  static_assert(std::is_same<REL_T, Elf_Rel>::value or
+                std::is_same<REL_T, Elf_Rela>::value, "REL_T must be Elf_Rel or Elf_Rela");
 
   const uint64_t offset_relocations = offset;
   const uint8_t shift = std::is_same<ELF_T, ELF32>::value ? 8 : 32;
@@ -1338,6 +1341,7 @@ void Parser::parse_section_relocations(uint64_t offset, uint64_t size) {
 
     std::unique_ptr<Relocation> reloc{new Relocation{&rel_hdr}};
     reloc->architecture_ = this->binary_->header_.machine_type();
+    reloc->applies_to_ = applies_to;
     if (this->binary_->header().file_type() == ELF::E_TYPE::ET_REL and
         this->binary_->segments().size() == 0) {
       reloc->purpose(RELOCATION_PURPOSES::RELOC_PURPOSE_OBJECT);

--- a/src/ELF/Relocation.cpp
+++ b/src/ELF/Relocation.cpp
@@ -36,7 +36,8 @@ Relocation::Relocation(void) :
   isRela_{false},
   symbol_{nullptr},
   architecture_{ARCH::EM_NONE},
-  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE}
+  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE},
+  applies_to_{nullptr}
 {}
 
 
@@ -47,7 +48,8 @@ Relocation::Relocation(const Relocation& other) :
   isRela_{other.isRela_},
   symbol_{nullptr},
   architecture_{other.architecture_},
-  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE}
+  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE},
+  applies_to_{other.applies_to_}
 {
 }
 
@@ -64,7 +66,8 @@ Relocation::Relocation(const Elf32_Rel* header) :
   isRela_{false},
   symbol_{nullptr},
   architecture_{ARCH::EM_NONE},
-  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE}
+  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE},
+  applies_to_{nullptr}
 {}
 
 
@@ -75,7 +78,8 @@ Relocation::Relocation(const Elf32_Rela* header) :
   isRela_{true},
   symbol_{nullptr},
   architecture_{ARCH::EM_NONE},
-  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE}
+  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE},
+  applies_to_{nullptr}
 {}
 
 
@@ -86,7 +90,8 @@ Relocation::Relocation(const Elf64_Rel* header) :
   isRela_{false},
   symbol_{nullptr},
   architecture_{ARCH::EM_NONE},
-  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE}
+  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE},
+  applies_to_{nullptr}
 {}
 
 
@@ -97,7 +102,8 @@ Relocation::Relocation(const Elf64_Rela* header)  :
   isRela_{true},
   symbol_{nullptr},
   architecture_{ARCH::EM_NONE},
-  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE}
+  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE},
+  applies_to_{nullptr}
 {}
 
 
@@ -108,7 +114,8 @@ Relocation::Relocation(uint64_t address, uint32_t type, int64_t addend, bool isR
   isRela_{isRela},
   symbol_{nullptr},
   architecture_{ARCH::EM_NONE},
-  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE}
+  purpose_{RELOCATION_PURPOSES::RELOC_PURPOSE_NONE},
+  applies_to_{nullptr}
 {}
 
 
@@ -120,6 +127,7 @@ void Relocation::swap(Relocation& other) {
   std::swap(this->symbol_,       other.symbol_);
   std::swap(this->architecture_, other.architecture_);
   std::swap(this->purpose_,      other.purpose_);
+  std::swap(this->applies_to_,   other.applies_to_);
 }
 
 int64_t Relocation::addend(void) const {
@@ -144,6 +152,17 @@ Symbol& Relocation::symbol(void) {
   return const_cast<Symbol&>(static_cast<const Relocation*>(this)->symbol());
 }
 
+const Section& Relocation::applies_to(void) const {
+  if (this->applies_to_ != nullptr) {
+    return *this->applies_to_;
+  } else {
+    throw not_found("No section associated with this relocation");
+  }
+}
+
+Section& Relocation::applies_to(void) {
+  return const_cast<Section&>(static_cast<const Relocation*>(this)->applies_to());
+}
 
 bool Relocation::is_rela(void) const {
   return this->isRela_;
@@ -167,6 +186,10 @@ RELOCATION_PURPOSES Relocation::purpose(void) const {
 
 bool Relocation::has_symbol(void) const {
   return this->symbol_ != nullptr;
+}
+
+bool Relocation::has_applies_to(void) const {
+  return this->applies_to_ != nullptr;
 }
 
 size_t Relocation::size(void) const {


### PR DESCRIPTION
This patch adds an `applies_to` field to the `ELF.Relocation` object that tracks with `ELF.Section` the relocation applies to in an ELF _object_ file. It's value is provided by the `ELF.Parser` when the latter analyzes an ELF object file. When dealing with object files, the field is necessary to properly interpret the meaning of the relocation's `address` field because in this context, instead of representing a virtual address, the address is relative to the beginning of the designated ELF section. 