### PR TITLE
Remove a hardcoded dependency to easylogging++

### DIFF
--- a/src/MachO/DyldInfo.cpp
+++ b/src/MachO/DyldInfo.cpp
@@ -17,7 +17,7 @@
 #include <iomanip>
 #include <sstream>
 
-#include "easylogging++.h"
+#include "LIEF/logging++.hpp"
 
 #include "LIEF/Abstract/Binary.hpp"
 


### PR DESCRIPTION
* So easylogging++ isn't required anymore when
  undefining LIEF_LOGGING_SUPPORT.