### PR TITLE
[PE] Pad section contents when rebuilding binary 

### DIFF
--- a/src/PE/Builder.cpp
+++ b/src/PE/Builder.cpp
@@ -540,14 +540,20 @@ Builder& Builder::operator<<(const Section& section) {
   std::copy(name, name + sizeof(header.Name), std::begin(header.Name));
   this->ios_.write(reinterpret_cast<uint8_t*>(&header), sizeof(pe_section));
 
+
   if (section.content().size() > section.size()) {
     LOG(WARNING) << section.name()
                  << " content size is bigger than section's header size"
                  << std::endl;
   }
+
+  // Pad section content with zeroes
+  std::vector<uint8_t> zero_pad (section.size() - section.content().size(), 0);
+
   const size_t saved_offset = this->ios_.tellp();
   this->ios_.seekp(section.offset());
   this->ios_.write(section.content());
+  this->ios_.write(zero_pad);
   this->ios_.seekp(saved_offset);
   return *this;
 }

--- a/src/PE/Builder.cpp
+++ b/src/PE/Builder.cpp
@@ -540,15 +540,18 @@ Builder& Builder::operator<<(const Section& section) {
   std::copy(name, name + sizeof(header.Name), std::begin(header.Name));
   this->ios_.write(reinterpret_cast<uint8_t*>(&header), sizeof(pe_section));
 
-
+  size_t pad_length = 0;
   if (section.content().size() > section.size()) {
     LOG(WARNING) << section.name()
                  << " content size is bigger than section's header size"
                  << std::endl;
   }
+  else {
+	  pad_length = section.size() - section.content().size();
+  }
 
   // Pad section content with zeroes
-  std::vector<uint8_t> zero_pad (section.size() - section.content().size(), 0);
+  std::vector<uint8_t> zero_pad (pad_length, 0);
 
   const size_t saved_offset = this->ios_.tellp();
   this->ios_.seekp(section.offset());


### PR DESCRIPTION
J'ai trouvé un bug assez bizarre : en régénérant des binaires à l'identiques, certaines dlls ne se chargeaient plus:

Ex :

```
PS > H:\Dev\LIEF\build\examples\cpp\Release\pe_builder.exe "C:\Windows\System32\kerberos.dll" "O:\kerberos.dll.rebuilt"
PE Rebuilder
kerberos.dll
PS > python -c "import ctypes;print(ctypes.cdll.LoadLibrary(r'C:\Windows\System32\kerberos.dll'))"
<CDLL 'C:\Windows\System32\kerberos.dll', handle 7ffc31980000 at 0x23dd1e68e80>
PS > python -c "import ctypes;print(ctypes.cdll.LoadLibrary(r'O:\kerberos.dll.rebuilt'))"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "***\AppData\Local\Programs\Python\Python36\lib\ctypes\__init__.py", line 426, in LoadLibrary
    return self._dlltype(name)
  File "***\AppData\Local\Programs\Python\Python36\lib\ctypes\__init__.py", line 348, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: [WinError 193] %1 n’est pas une application Win32 valide
```

La raison vient du fait que certaines sections (la plupart du temps c'est `reloc` qui se trouve être la dernière section) possède un `VirtualSize` inférieure à `SizeOfRawData` (ouais c'est chelou je sais). Dans ce cas là, tu prends le minimum au moment de parser les sections du binaire :

```
void Parser::parse_sections(void) {
  [...]

  for (size_t i = 0; i < numberof_sections; ++i) {
    std::unique_ptr<Section> section{new Section{&sections[i]}};

    uint32_t size_to_read = 0;
    uint32_t offset = sections[i].PointerToRawData;
    first_section_offset = std::min(first_section_offset, offset);

    if (sections[i].VirtualSize > 0) {
      size_to_read = std::min(sections[i].VirtualSize, sections[i].SizeOfRawData); // According to Corkami
    } else {
      size_to_read = sections[i].SizeOfRawData;
    }

    [...]
```

Jusque là, pas de lézards. Le souci vient au moment de régénérer le binaire : le contenu de la section est recopié tel quel, mais le header de section utilise `SizeOfRawData` comme taille alors que son contenu est de taille `VirtualSize`.

Le fix consiste à padder le contenu de la section avec des zéros si `SizeOfRawData` est supérieur à la taille des données de la section.

Test avec fix :

```
PS > H:\Dev\LIEF\build\examples\cpp\Release\pe_builder.exe "C:\Windows\System32\kerberos.dll" "O:\kerberos.dll.rebuilt"
PE Rebuilder
kerberos.dll
PS > python -c "import ctypes;print(ctypes.cdll.LoadLibrary(r'C:\Windows\System32\kerberos.dll'))"
<CDLL 'C:\Windows\System32\kerberos.dll', handle 7ffc31980000 at 0x23dd1e68e80>
PS > python -c "import ctypes;print(ctypes.cdll.LoadLibrary(r'O:\kerberos.dll.rebuilt'))"
<CDLL 'O:\kerberos.dll.rebuilt', handle 7ffbd7920000 at 0x2a6033f8e80>
PS >Get-FileHash "C:\Windows\System32\kerberos.dll" -Algorithm SHA1
B2CFC3E4F064298FDA3DA4D20790A8BDA494B305
PS >Get-FileHash "O:\kerberos.dll" -Algorithm SHA1
B2CFC3E4F064298FDA3DA4D20790A8BDA494B305
```

PS : 

```
PS > (Get-Item C:\Windows\System32\kerberos.dll).VersionInfo

ProductVersion   FileVersion      FileName
--------------   -----------      --------
10.0.17134.103   10.0.17134.10... C:\Windows\System32\kerberos.dll
```
