### PR TITLE
allow for reproducible builds by zeroing non-initialized dosheader fields

### DIFF
--- a/src/PE/Builder.cpp
+++ b/src/PE/Builder.cpp
@@ -526,6 +526,7 @@ Builder& Builder::operator<<(const DataDirectory& data_directory) {
 Builder& Builder::operator<<(const Section& section) {
 
   pe_section header;
+  memset(&header, 0, sizeof(pe_section));
   header.VirtualAddress       = static_cast<uint32_t>(section.virtual_address());
   header.VirtualSize          = static_cast<uint32_t>(section.virtual_size());
   header.SizeOfRawData        = static_cast<uint32_t>(section.size());
@@ -537,7 +538,8 @@ Builder& Builder::operator<<(const Section& section) {
   header.Characteristics      = static_cast<uint32_t>(section.characteristics());
   const char* name            = section.name().c_str();
 
-  std::copy(name, name + sizeof(header.Name), std::begin(header.Name));
+  uint32_t name_length = std::min<uint32_t>(strlen(name), sizeof(header.Name));
+  std::copy(name, name + name_length, std::begin(header.Name));
   this->ios_.write(reinterpret_cast<uint8_t*>(&header), sizeof(pe_section));
 
   size_t pad_length = 0;

--- a/src/PE/DosHeader.cpp
+++ b/src/PE/DosHeader.cpp
@@ -41,8 +41,10 @@ DosHeader::DosHeader(void) :
   initialRelativeCS_{0},
   addressOfRelocationTable_{0x40},
   overlayNumber_{0},
+  reserved_{0},
   oEMid_{0},
   oEMinfo_{0},
+  reserved2_{0},
   addressOfNewExeHeader_{0xF0} // or 0xE8
 {}
 


### PR DESCRIPTION
Multiple runs of the same code would result in binaries with different hashes, this PR fixes that issue.