### PR TITLE
api/c: Add explict size fields for extracted content fields

### DIFF
--- a/api/c/MachO/Segment.cpp
+++ b/api/c/MachO/Segment.cpp
@@ -44,6 +44,7 @@ void init_c_segments(Macho_Binary_t* c_binary, Binary* binary) {
     c_binary->segments[i]->numberof_sections = segment.numberof_sections();
     c_binary->segments[i]->flags             = segment.flags();
     c_binary->segments[i]->content           = content;
+    c_binary->segments[i]->size              = segment_content.size();
     c_binary->segments[i]->sections          = nullptr; //TODO
   }
 

--- a/api/c/PE/Section.cpp
+++ b/api/c/PE/Section.cpp
@@ -43,6 +43,7 @@ void init_c_sections(Pe_Binary_t* c_binary, Binary* binary) {
     c_binary->sections[i]->pointerto_line_numbers  = b_section.pointerto_line_numbers();
     c_binary->sections[i]->characteristics         = b_section.characteristics();
     c_binary->sections[i]->content                 = content;
+    c_binary->sections[i]->content_size            = section_content.size();
     c_binary->sections[i]->entropy                 = b_section.entropy();
   }
   c_binary->sections[sections.size()] = nullptr;

--- a/api/c/include/LIEF/MachO/Segment.h
+++ b/api/c/include/LIEF/MachO/Segment.h
@@ -41,6 +41,7 @@ struct Macho_Segment_t {
   uint32_t          numberof_sections;
   uint32_t          flags;
   uint8_t*          content;
+  uint64_t          size;
   Macho_Section_t** sections;
 };
 

--- a/api/c/include/LIEF/PE/Section.h
+++ b/api/c/include/LIEF/PE/Section.h
@@ -43,6 +43,7 @@ struct Pe_Section_t {
   uint32_t    characteristics;
 
   uint8_t*    content;
+  uint64_t    content_size;
   double      entropy;
 
 };


### PR DESCRIPTION
Corrupted files may cause section or segment contents not to be
available entirely. However, C-based client code is not able to detect
this which may cause out-of-bounds reads when accessing data from the
.content fields.

Note: This is a silent ABI-breaking change because it changes struct layouts.

Note: Naming is inconsistent: .size was already taken in PE Sections.