### PR TITLE
PE ResourcesManager: correctly handle empty strings

### DIFF
--- a/src/PE/ResourcesManager.cpp
+++ b/src/PE/ResourcesManager.cpp
@@ -589,6 +589,8 @@ ResourceStringFileInfo ResourcesManager::get_string_file_info(const VectorStream
     // Parse 'String'
     // ==============
     while (stream.pos() < end_offset) {
+      const size_t string_offset = stream.pos();
+
       const uint16_t string_length = stream.read<uint16_t>();
       VLOG(VDEBUG) << "Length of the 'string' struct: 0x" << std::hex << string_length;
 
@@ -602,8 +604,13 @@ ResourceStringFileInfo ResourcesManager::get_string_file_info(const VectorStream
       VLOG(VDEBUG) << "Key: " << u16tou8(key);
       stream.align(sizeof(uint32_t));
 
-      std::u16string value = stream.read_u16string();
-      VLOG(VDEBUG) << "Value: " << u16tou8(value);
+      std::u16string value;
+      if (string_value_length > 0 && stream.pos() < string_offset + string_length) {
+        value = stream.read_u16string();
+        VLOG(VDEBUG) << "Value: " << u16tou8(value);
+      } else {
+        VLOG(VDEBUG) << "Value: (empty)";
+      }
 
       stream.align(sizeof(uint32_t));
       lang_code_item.items_.emplace(key, value);


### PR DESCRIPTION
addresses https://github.com/lief-project/LIEF/issues/245

Implements the fixes described there. The empty string is now parsed correctly:

![image](https://user-images.githubusercontent.com/156560/50121922-a824d400-0217-11e9-916b-445a54396481.png)

Note that I haven't inspected the `get_var_file_info` routine, which could have a similar issue.
