### PR TITLE
resources manager: fix parsing string info by trusting k-v pair header

### DIFF
--- a/src/PE/ResourcesManager.cpp
+++ b/src/PE/ResourcesManager.cpp
@@ -637,6 +637,11 @@ ResourceStringFileInfo ResourcesManager::get_string_file_info(const VectorStream
         VLOG(VDEBUG) << "Value: (empty)";
       }
 
+      const size_t expected_end = string_offset + string_length;
+
+      if (stream.pos() < expected_end && expected_end < end_offset) {
+        stream.setpos(expected_end);
+      }
       stream.align(sizeof(uint32_t));
       lang_code_item.items_.emplace(key, value);
     }


### PR DESCRIPTION
closes #256 

with this patch, the version info is parsed correctly:

![image](https://user-images.githubusercontent.com/156560/50997690-dfbb2f00-14ea-11e9-8935-f8af1a710ee5.png)

i have *not* inspected other parts of the resource parser (e.g. var info) for similar bugs since i don't have a test case.