### PR TITLE
Add min_size parameters to Binary::strings function

### DIFF
--- a/api/python/ELF/objects/pyBinary.cpp
+++ b/api/python/ELF/objects/pyBinary.cpp
@@ -435,10 +435,11 @@ void create<Binary>(py::module& m) {
         "symbol_name"_a,
         py::return_value_policy::reference)
 
-    .def_property_readonly("strings",
-        &Binary::strings,
+    .def("strings",
+        static_cast<Binary::string_list_t (Binary::*)(const size_t) const>(&Binary::strings),
         "Return list of strings used in the current ELF file.\n"
         "Basically we look for string in the ``.roadata`` section",
+        "min_size"_a = 5,
         py::return_value_policy::move)
 
     .def("remove_static_symbol",

--- a/include/LIEF/ELF/Binary.hpp
+++ b/include/LIEF/ELF/Binary.hpp
@@ -270,7 +270,7 @@ class LIEF_API Binary : public LIEF::Binary {
   //! Return list of strings used by the ELF binrary.
   //!
   //! Basically we look for string in the ``.roadata``
-  string_list_t strings(void) const;
+  string_list_t strings(const size_t min_size = 5) const;
 
   //! @brief Remove symbols with the given name in boths
   //!   * dynamic symbols

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -544,8 +544,7 @@ const Symbol& Binary::get_static_symbol(const std::string& name) const {
 }
 
 
-Binary::string_list_t Binary::strings(void) const {
-  static constexpr size_t MIN_STRING_SIZE = 5;
+Binary::string_list_t Binary::strings(size_t min_size) const {
   Binary::string_list_t list;
   if (not this->has_section(".rodata")) {
     return list;
@@ -561,7 +560,7 @@ Binary::string_list_t Binary::strings(void) const {
 
     // Terminator
     if (c == '\0') {
-      if (current.size() >= MIN_STRING_SIZE) {
+      if (current.size() >= min_size) {
         list.push_back(std::move(current));
         continue;
       }


### PR DESCRIPTION
This PR add the possibility to pass a "min_size" parameter to the Binary::strings function to filter the results.