### PR TITLE
Counter bugs in PE resources manipulation functions

### DIFF
--- a/src/PE/ResourceNode.cpp
+++ b/src/PE/ResourceNode.cpp
@@ -114,7 +114,7 @@ ResourceNode& ResourceNode::add_child(const ResourceDirectory& child) {
   this->childs_.push_back(new_node);
 
   if (ResourceDirectory* dir = dynamic_cast<ResourceDirectory*>(this)) {
-    if (this->has_name()) {
+    if (child.has_name()) {
       dir->numberof_name_entries(dir->numberof_name_entries() + 1);
     } else {
       dir->numberof_id_entries(dir->numberof_id_entries() + 1);
@@ -131,7 +131,7 @@ ResourceNode& ResourceNode::add_child(const ResourceData& child) {
   this->childs_.push_back(new_node);
 
   if (ResourceDirectory* dir = dynamic_cast<ResourceDirectory*>(this)) {
-    if (this->has_name()) {
+    if (child.has_name()) {
       dir->numberof_name_entries(dir->numberof_name_entries() + 1);
     } else {
       dir->numberof_id_entries(dir->numberof_id_entries() + 1);

--- a/src/PE/ResourceNode.cpp
+++ b/src/PE/ResourceNode.cpp
@@ -172,7 +172,7 @@ void ResourceNode::delete_child(const ResourceNode& node) {
 
   if (this->is_directory()) {
     ResourceDirectory* dir = dynamic_cast<ResourceDirectory*>(this);
-    if (this->has_name()) {
+    if ((*it_node)->has_name()) {
       dir->numberof_name_entries(dir->numberof_name_entries() - 1);
     } else {
       dir->numberof_id_entries(dir->numberof_id_entries() - 1);


### PR DESCRIPTION
Functions check if parent node `has_name` instead of checking it on the child passed in parameter.