### PR TITLE
Add support for adding LC_UNIXTHREAD commands in a MachO

### DIFF
--- a/include/LIEF/MachO/Builder.hpp
+++ b/include/LIEF/MachO/Builder.hpp
@@ -103,6 +103,9 @@ class LIEF_API Builder {
   template<class T>
   void build(DyldEnvironment* de);
 
+  template<class T>
+  void build(ThreadCommand* tc);
+
   template <typename T>
   void build_segments(void);
 

--- a/include/LIEF/MachO/ThreadCommand.hpp
+++ b/include/LIEF/MachO/ThreadCommand.hpp
@@ -34,7 +34,8 @@ class LIEF_API ThreadCommand : public LoadCommand {
   friend class BinaryParser;
   public:
     ThreadCommand(void);
-    ThreadCommand(const thread_command *cmd);
+    ThreadCommand(const thread_command *cmd, CPU_TYPES arch=CPU_TYPES::CPU_TYPE_ANY);
+    ThreadCommand(uint32_t flavor, uint32_t count, CPU_TYPES arch=CPU_TYPES::CPU_TYPE_ANY);
 
     ThreadCommand& operator=(const ThreadCommand& copy);
     ThreadCommand(const ThreadCommand& copy);
@@ -43,8 +44,9 @@ class LIEF_API ThreadCommand : public LoadCommand {
 
     virtual ~ThreadCommand(void);
 
-    uint32_t flavor(void) const;
-    uint32_t count(void) const;
+    uint32_t  flavor(void) const;
+    uint32_t  count(void) const;
+    CPU_TYPES architecture(void) const;
 
     const std::vector<uint8_t>& state(void) const;
     std::vector<uint8_t>& state(void);
@@ -54,6 +56,7 @@ class LIEF_API ThreadCommand : public LoadCommand {
     void state(const std::vector<uint8_t>& state);
     void flavor(uint32_t flavor);
     void count(uint32_t count);
+    void architecture(CPU_TYPES arch);
 
     bool operator==(const ThreadCommand& rhs) const;
     bool operator!=(const ThreadCommand& rhs) const;

--- a/src/MachO/Builder.cpp
+++ b/src/MachO/Builder.cpp
@@ -153,6 +153,11 @@ void Builder::build(void) {
       continue;
     }
 
+    if (cmd->is<ThreadCommand>()) {
+      this->build<T>(cmd->as<ThreadCommand>());
+      continue;
+    }
+
     if (cmd->is<BuildVersion>()) {
       this->build<T>(cmd->as<BuildVersion>());
       continue;


### PR DESCRIPTION
Add support for adding LC_UNIXTHREAD commands in a MachO.

Also include:
- Fix ```Binary::remove``` (exception raised)
- Fix symbols' values when segments are shifted