### PR TITLE
Fixes issues with printing/serializing notes

### DIFF
--- a/include/LIEF/ELF/NoteDetails.hpp
+++ b/include/LIEF/ELF/NoteDetails.hpp
@@ -47,6 +47,8 @@ class LIEF_API NoteDetails : public Object {
   public:
   virtual ~NoteDetails(void);
 
+  virtual NoteDetails* clone(void) const;
+
   const Note::description_t& description(void) const;
 
   virtual void dump(std::ostream& os) const;

--- a/include/LIEF/ELF/NoteDetails/AndroidNote.hpp
+++ b/include/LIEF/ELF/NoteDetails/AndroidNote.hpp
@@ -58,6 +58,8 @@ class LIEF_API AndroidNote : public NoteDetails {
   using NoteDetails::NoteDetails;
   using description_t = typename Note::description_t;
 
+  virtual AndroidNote* clone(void) const override;
+
   //! Target SDK version
   uint32_t sdk_version(void) const;
 

--- a/include/LIEF/ELF/NoteDetails/NoteAbi.hpp
+++ b/include/LIEF/ELF/NoteDetails/NoteAbi.hpp
@@ -52,6 +52,8 @@ class LIEF_API NoteAbi : public NoteDetails {
 
   static NoteAbi make(Note& note);
 
+  virtual NoteAbi* clone(void) const override;
+
   public:
   using NoteDetails::NoteDetails;
   using description_t = typename Note::description_t;

--- a/include/LIEF/ELF/NoteDetails/core/CoreAuxv.hpp
+++ b/include/LIEF/ELF/NoteDetails/core/CoreAuxv.hpp
@@ -45,6 +45,8 @@ class LIEF_API CoreAuxv : public NoteDetails {
   public:
   static CoreAuxv make(Note& note);
 
+  virtual CoreAuxv* clone(void) const override;
+
   //! Auxiliary values
   const val_context_t& values(void) const;
 

--- a/include/LIEF/ELF/NoteDetails/core/CoreFile.hpp
+++ b/include/LIEF/ELF/NoteDetails/core/CoreFile.hpp
@@ -54,6 +54,8 @@ class LIEF_API CoreFile : public NoteDetails {
   public:
   static CoreFile make(Note& note);
 
+  virtual CoreFile* clone(void) const override;
+
   //! Number of coredump file entries
   uint64_t count(void) const;
 

--- a/include/LIEF/ELF/NoteDetails/core/CorePrPsInfo.hpp
+++ b/include/LIEF/ELF/NoteDetails/core/CorePrPsInfo.hpp
@@ -41,6 +41,8 @@ class LIEF_API CorePrPsInfo : public NoteDetails {
   public:
   static CorePrPsInfo make(Note& note);
 
+  virtual CorePrPsInfo* clone(void) const override;
+
   //! Process file name
   std::string file_name(void) const;
 

--- a/include/LIEF/ELF/NoteDetails/core/CorePrStatus.hpp
+++ b/include/LIEF/ELF/NoteDetails/core/CorePrStatus.hpp
@@ -81,6 +81,8 @@ class LIEF_API CorePrStatus : public NoteDetails {
   public:
   static CorePrStatus make(Note& note);
 
+  virtual CorePrStatus* clone(void) const override;
+
   //! Info associated with the signal
   const Elf_siginfo& siginfo(void) const;
 

--- a/include/LIEF/ELF/NoteDetails/core/CoreSigInfo.hpp
+++ b/include/LIEF/ELF/NoteDetails/core/CoreSigInfo.hpp
@@ -43,6 +43,8 @@ class LIEF_API CoreSigInfo : public NoteDetails {
   public:
   static CoreSigInfo make(Note& note);
 
+  virtual CoreSigInfo* clone(void) const override;
+
   //! Signal number.
   int32_t signo(void) const;
 

--- a/src/ELF/Builder.cpp
+++ b/src/ELF/Builder.cpp
@@ -165,8 +165,11 @@ void Builder::build(NOTE_TYPES type) {
     { NOTE_TYPES::NT_GNU_ABI_TAG,      ".note.ABI-tag"          },
     { NOTE_TYPES::NT_GNU_ABI_TAG,      ".note.android.ident"    },
 
+    { NOTE_TYPES::NT_GNU_HWCAP,        ".note.gnu.hwcap"        },
     { NOTE_TYPES::NT_GNU_BUILD_ID,     ".note.gnu.build-id"     },
     { NOTE_TYPES::NT_GNU_GOLD_VERSION, ".note.gnu.gold-version" },
+
+    { NOTE_TYPES::NT_UNKNOWN,          ".note"                  },
   };
 
   Segment& segment_note = this->binary_->get(SEGMENT_TYPES::PT_NOTE);
@@ -218,6 +221,7 @@ void Builder::build(NOTE_TYPES type) {
     Section& section_added = this->binary_->add(section, false);
     section_added.offset(segment_note.file_offset() + this->note_offset(note));
     section_added.size(note.size());
+    section_added.alignment(4);
   }
 }
 

--- a/src/ELF/Builder.tcc
+++ b/src/ELF/Builder.tcc
@@ -2060,8 +2060,10 @@ void Builder::build_notes(void) {
   //TODO: .note.netbds etc
   if (this->binary_->header().file_type() != E_TYPE::ET_CORE) {
     this->build(NOTE_TYPES::NT_GNU_ABI_TAG);
+    this->build(NOTE_TYPES::NT_GNU_HWCAP);
     this->build(NOTE_TYPES::NT_GNU_BUILD_ID);
     this->build(NOTE_TYPES::NT_GNU_GOLD_VERSION);
+    this->build(NOTE_TYPES::NT_UNKNOWN);
   }
 
 

--- a/src/ELF/Note.cpp
+++ b/src/ELF/Note.cpp
@@ -47,7 +47,10 @@ Note::Note(const Note& other):
   name_(other.name_),
   type_(other.type_),
   description_(other.description_)
-{}
+{
+  auto&& details = other.details_;
+  this->details_ = std::make_pair(details.first, std::unique_ptr<NoteDetails>{details.second->clone()});
+}
 
 void Note::swap(Note& other) {
   std::swap(this->binary_,      other.binary_);

--- a/src/ELF/NoteDetails.cpp
+++ b/src/ELF/NoteDetails.cpp
@@ -43,6 +43,9 @@ NoteDetails::NoteDetails(Note& note):
   note_{&note}
 {}
 
+NoteDetails* NoteDetails::clone(void) const {
+  return new NoteDetails(*this);
+}
 
 const Note::description_t& NoteDetails::description(void) const {
   if (this->note_ == nullptr) {

--- a/src/ELF/NoteDetails/AndroidNote.cpp
+++ b/src/ELF/NoteDetails/AndroidNote.cpp
@@ -43,6 +43,10 @@ AndroidNote::AndroidNote(Note& note) :
   ndk_build_number_{}
 {}
 
+AndroidNote* AndroidNote::clone(void) const {
+  return new AndroidNote(*this);
+}
+
 uint32_t AndroidNote::sdk_version(void) const {
   return this->sdk_version_;
 }

--- a/src/ELF/NoteDetails/NoteAbi.cpp
+++ b/src/ELF/NoteDetails/NoteAbi.cpp
@@ -36,6 +36,10 @@ NoteAbi NoteAbi::make(Note& note) {
   return abi;
 }
 
+NoteAbi* NoteAbi::clone(void) const {
+  return new NoteAbi(*this);
+}
+
 NoteAbi::NoteAbi(Note& note) :
   NoteDetails::NoteDetails{note},
   version_{{0, 0, 0}},

--- a/src/ELF/NoteDetails/core/CoreAuxv.cpp
+++ b/src/ELF/NoteDetails/core/CoreAuxv.cpp
@@ -37,6 +37,10 @@ CoreAuxv CoreAuxv::make(Note& note) {
   return pinfo;
 }
 
+CoreAuxv* CoreAuxv::clone(void) const {
+  return new CoreAuxv(*this);
+}
+
 
 const CoreAuxv::val_context_t& CoreAuxv::values(void) const {
   return this->ctx_;

--- a/src/ELF/NoteDetails/core/CoreFile.cpp
+++ b/src/ELF/NoteDetails/core/CoreFile.cpp
@@ -36,6 +36,10 @@ CoreFile CoreFile::make(Note& note) {
   return file;
 }
 
+CoreFile* CoreFile::clone(void) const {
+  return new CoreFile(*this);
+}
+
 
 uint64_t CoreFile::count(void) const {
   return this->files_.size();

--- a/src/ELF/NoteDetails/core/CorePrPsInfo.cpp
+++ b/src/ELF/NoteDetails/core/CorePrPsInfo.cpp
@@ -43,6 +43,10 @@ CorePrPsInfo CorePrPsInfo::make(Note& note) {
   return pinfo;
 }
 
+CorePrPsInfo* CorePrPsInfo::clone(void) const {
+  return new CorePrPsInfo(*this);
+}
+
 std::string CorePrPsInfo::file_name(void) const {
   return this->file_name_;
 }

--- a/src/ELF/NoteDetails/core/CorePrStatus.cpp
+++ b/src/ELF/NoteDetails/core/CorePrStatus.cpp
@@ -37,6 +37,9 @@ CorePrStatus CorePrStatus::make(Note& note) {
   return pinfo;
 }
 
+CorePrStatus* CorePrStatus::clone(void) const {
+  return new CorePrStatus(*this);
+}
 
 const CorePrStatus::reg_context_t& CorePrStatus::reg_context(void) const {
   return this->ctx_;

--- a/src/ELF/NoteDetails/core/CoreSigInfo.cpp
+++ b/src/ELF/NoteDetails/core/CoreSigInfo.cpp
@@ -36,6 +36,10 @@ CoreSigInfo CoreSigInfo::make(Note& note) {
   return pinfo;
 }
 
+CoreSigInfo* CoreSigInfo::clone(void) const {
+  return new CoreSigInfo(*this);
+}
+
 int32_t CoreSigInfo::signo(void) const {
   return this->siginfo_.si_signo;
 }

--- a/tests/elf/test_notes.py
+++ b/tests/elf/test_notes.py
@@ -17,6 +17,8 @@ Logger.set_level(lief.LOGGING_LEVEL.WARNING)
 from unittest import TestCase
 from utils import get_sample
 
+from contextlib import redirect_stdout
+from io import StringIO
 
 class TestNotes(TestCase):
     LOGGER = logging.getLogger(__name__)
@@ -86,6 +88,12 @@ class TestNotes(TestCase):
         self.assertIn(lief.ELF.NOTE_TYPES.GOLD_VERSION, etterlog_updated)
 
         self.safe_delete(output)
+
+        # The string printed is largely irrelevant, but running print ensures no regression occurs in a previous Note::dump segfault
+        # https://github.com/lief-project/LIEF/issues/300
+        with StringIO() as temp_stdout:
+            with redirect_stdout(temp_stdout):
+                print(etterlog)
 
 
     def test_android_note(self):


### PR DESCRIPTION
Related issue:
#300 

- Adds ability to clone `NoteDetails` objects to fixe a potential segfault in `LIEF::ELF::Note::dump`
- Adds the ability to write notes that are manually added by the user through `lief.add(life.ELF.Note(...))` to resulting binary by fixing an alignment bug
- Adds the ability to write `NT_GNU_HWCAP` and `NT_UNKNOWN` notes to resulting binary

Example that demonstrates updated functionality:
```
# mybin.bin only has a GNU ABI Tag note to begin with
mybin = lief.parse("mybin.bin")
mybin.add(lief.ELF.Note("GNU", lief.ELF.NOTE_TYPES.BUILD_ID, [0xb, 0xe, 0xe, 0xf]))
mybin.add(lief.ELF.Note("GNU", lief.ELF.NOTE_TYPES.HWCAP, [0, 0, 0, 0, 0, 0, 0, 0]))
mybin.add(lief.ELF.Note("CustomStr", lief.ELF.NOTE_TYPES.UNKNOWN, list(map(ord, "Str2"))))
print(mybin)
mybin.write("modified.bin")
modified = lief.parse("modified.bin")
print(modified)
```
Externally, `readelf -n modified.bin` also supports displaying the notes that are added