### PR TITLE
Update the PE Authenticode parsing code

### DIFF
--- a/src/PE/signature/AuthenticatedAttributes.cpp
+++ b/src/PE/signature/AuthenticatedAttributes.cpp
@@ -50,10 +50,22 @@ void AuthenticatedAttributes::accept(Visitor& visitor) const {
 
 std::ostream& operator<<(std::ostream& os, const AuthenticatedAttributes& authenticated_attributes) {
   constexpr uint8_t wsize = 30;
+  std::string content_type = authenticated_attributes.content_type();
+  if (content_type.empty()) {
+    content_type = "N/A";
+  }
+  std::string program_name = u16tou8(authenticated_attributes.program_name());
+  if (program_name.empty()) {
+    program_name = "N/A";
+  }
+  std::string url = authenticated_attributes.more_info();
+  if (url.empty()) {
+    url = "N/A";
+  }
   os << std::hex << std::left;
-  os << std::setw(wsize) << std::setfill(' ') << "Content type: " << authenticated_attributes.content_type()          << std::endl;
-  os << std::setw(wsize) << std::setfill(' ') << "Program name: " << u16tou8(authenticated_attributes.program_name()) << std::endl;
-  os << std::setw(wsize) << std::setfill(' ') << "URL : "         << authenticated_attributes.more_info()             << std::endl;
+  os << std::setw(wsize) << std::setfill(' ') << "Content type: " << content_type << std::endl;
+  os << std::setw(wsize) << std::setfill(' ') << "Program name: " << program_name << std::endl;
+  os << std::setw(wsize) << std::setfill(' ') << "URL : "         << url          << std::endl;
 
   return os;
 }

--- a/src/PE/signature/OIDToString.cpp
+++ b/src/PE/signature/OIDToString.cpp
@@ -997,6 +997,7 @@ const char* oid_to_string(const oid_t& oid) {
     { "1.3.6.1.4.1.311.2.2.1",            "CTL_TRUSTED_CODESIGNING_CA_LIST" },
     { "1.3.6.1.4.1.311.2.2.2",            "CTL_TRUSTED_CLIENT_AUTH_CA_LIST" },
     { "1.3.6.1.4.1.311.2.2.3",            "CTL_TRUSTED_SERVER_AUTH_CA_LIST" },
+    { "1.3.6.1.4.1.311.2.4.1",            "SPC_NESTED_SIGNATURES" },
     { "1.3.6.1.4.1.311.3.2.1",            "TIMESTAMP_REQUEST" },
     { "1.3.6.1.4.1.311.10.1",             "CERT_TRUST_LIST" },
     { "1.3.6.1.4.1.311.10.1.1",           "SORTED_CTL" },


### PR DESCRIPTION
Changes:
 - Allow UTF8String and IA5String types when parsing the Issuer fields
   (previously only PrintableString types were handled).  Handling these
   three types should be sufficient, based on the default types indicated
   at https://github.com/ARMmbed/mbedtls/blob/master/library/x509_create.c#L52.
   The approach used is similar to what's done in mbedtls's internal
   x509_get_attr_type_value function.

   Examples:
```
     8a364e0881fd7201cd6f0a0ff747451c9b93182d5699afb28ad8466f7f726660:
     SEQUENCE (4 elem)
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 2.5.4.6 countryName (X.520 DN component)
           PrintableString PL
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 2.5.4.10 organizationName (X.520 DN component)
           UTF8String Unizeto Technologies S.A.
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 2.5.4.11 organizationalUnitName (X.520 DN component)
           UTF8String Certum Certification Authority
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 2.5.4.3 commonName (X.520 DN component)
           UTF8String Certum Code Signing CA SHA2

     From a test binary compiled with osslsigncode:
     SEQUENCE (6 elem)
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 2.5.4.6 countryName (X.520 DN component)
           PrintableString US
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 2.5.4.8 stateOrProvinceName (X.520 DN component)
           UTF8String State
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 2.5.4.7 localityName (X.520 DN component)
           UTF8String City
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 2.5.4.10 organizationName (X.520 DN component)
           UTF8String Cisco Talos
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 2.5.4.11 organizationalUnitName (X.520 DN component)
           UTF8String Test CA 1704a8ea9e24d8ed
       SET (1 elem)
         SEQUENCE (2 elem)
           OBJECT IDENTIFIER 1.2.840.113549.1.9.1 emailAddress (PKCS #9. Deprecated, use an altName extension instead)
           IA5String rfc2606@example.net
```

 - Allow any order for the AuthenticatedAttributes, and ignore ones that
   aren't recognized. The code was looking for a strict ordering of the
   attributes, but Windows seems to be OK with any order.
   Example:
```
     From f91e258ea71dcbfc82371b2ee3e20852e45bef0cb946223d1141a6ef1dfb793f:
     SEQUENCE (2 elem)
       OBJECT IDENTIFIER 1.3.6.1.4.1.311.2.1.12 spcSpOpusInfo (Microsoft code signing)
       SET (1 elem)
         SEQUENCE (0 elem)
     SEQUENCE (2 elem)
       OBJECT IDENTIFIER 1.2.840.113549.1.9.3 contentType (PKCS #9)
       SET (1 elem)
         OBJECT IDENTIFIER 1.3.6.1.4.1.311.2.1.4 spcIndirectDataContext (Microsoft code signing)
     SEQUENCE (2 elem)
       OBJECT IDENTIFIER 1.3.6.1.4.1.311.2.1.11 spcStatementType (Microsoft code signing)
       SET (1 elem)
         SEQUENCE (1 elem)
           OBJECT IDENTIFIER 1.3.6.1.4.1.311.2.1.21 individualCodeSigning (Microsoft)
     SEQUENCE (2 elem)
       OBJECT IDENTIFIER 1.2.840.113549.1.9.4 messageDigest (PKCS #9)
       SET (1 elem)
         OCTET STRING (20 byte) 7C87D331C6E62C0EC840BC23CA63FBC2CE68586F
```

 - Allow the program name and/or more info to be missing from SpcSpOpusInfo.
   Examples:
```
     8a364e0881fd7201cd6f0a0ff747451c9b93182d5699afb28ad8466f7f726660:
     SEQUENCE (2 elem)
       OBJECT IDENTIFIER 1.3.6.1.4.1.311.2.1.12 spcSpOpusInfo (Microsoft code signing)
       SET (1 elem)
         SEQUENCE (0 elem)

     0059fb3f225c5784789622eeccb97197d591972851b63d59f5bd107ddfdb7a21:
     SEQUENCE (2 elem)
       OBJECT IDENTIFIER 1.3.6.1.4.1.311.2.1.12 spcSpOpusInfo (Microsoft code signing)
       SET (1 elem)
         SEQUENCE (1 elem)
           [0] (1 elem)
             [0] (22 byte) 0047006F0054006F0020004F00700065006E00650072
```

 - I removed the #if 0 preventing ContentInfo from being populated, and the code
   worked with all of the test samples I used... Is there another reason this code
   is commented out?

 - The authenticated_attribytes content_name_ member now gets populated. This
   was commented out with a TODO by it... Is there a reason this field wasn't
   being populated?

 - When the SignerInfo is printed, it will now show 'N/A' if no value was
   parsed out from the executable


I'm not familiar with a lot of the C++ constructs and language features used in the codebase, but I tried to piece this together based on how other parts of the code worked.  Definitely make sure I didn't break anything, though!