### PR TITLE
Unify SignerInfo issuer field format

### DIFF
--- a/examples/python/pe_reader.py
+++ b/examples/python/pe_reader.py
@@ -335,9 +335,8 @@ def print_signature(binary):
 
     print("-- Signer Info --")
     signer_info = signature.signer_info
-    issuer_str = " ".join(map(lambda e : oid_to_string(e[0]) + " = " + e[1], signer_info.issuer[0]))
     print(format_dec.format("Version:",             signer_info.version))
-    print(format_str.format("Issuer:",              issuer_str))
+    print(format_str.format("Issuer:",              signer_info.issuer[0]))
     print(format_str.format("Digest Algorithm:",    oid_to_string(signer_info.digest_algorithm)))
     print(format_str.format("Signature algorithm:", oid_to_string(signer_info.signature_algorithm)))
     print(format_str.format("Program name:",        signer_info.authenticated_attributes.program_name))

--- a/include/LIEF/PE/signature/types.hpp
+++ b/include/LIEF/PE/signature/types.hpp
@@ -26,7 +26,7 @@ namespace PE {
 class x509;
 
 using oid_t        = std::string;
-using issuer_t     = std::pair<std::vector<std::pair<std::string, std::string>>, std::vector<uint8_t>>;
+using issuer_t     = std::pair<std::string, std::vector<uint8_t>>;
 using it_const_crt = const_ref_iterator<const std::vector<x509>&>;
 }
 }

--- a/src/PE/DataDirectory.cpp
+++ b/src/PE/DataDirectory.cpp
@@ -131,8 +131,8 @@ bool DataDirectory::operator!=(const DataDirectory& rhs) const {
 std::ostream& operator<<(std::ostream& os, const DataDirectory& entry) {
   os << std::hex;
   os << "Data directory \"" << to_string(entry.type()) << "\"" << std::endl;
-  os << std::setw(10) << std::left << std::setfill(' ') << "RVA: "  << entry.RVA()  << std::endl;
-  os << std::setw(10) << std::left << std::setfill(' ') << "Size: " << entry.size() << std::endl;
+  os << std::setw(10) << std::left << std::setfill(' ') << "RVA: 0x"  << entry.RVA()  << std::endl;
+  os << std::setw(10) << std::left << std::setfill(' ') << "Size: 0x" << entry.size() << std::endl;
   if (entry.has_section()) {
     os << std::setw(10) << std::left << std::setfill(' ') << "Section: " << entry.section().name() << std::endl;
   }

--- a/src/PE/json.cpp
+++ b/src/PE/json.cpp
@@ -666,17 +666,7 @@ void JsonVisitor::visit(const SignerInfo& signerinfo) {
   this->node_["digest_algorithm"]         = signerinfo.digest_algorithm();
   this->node_["signature_algorithm"]      = signerinfo.signature_algorithm();
   this->node_["authenticated_attributes"] = authenticated_attributes_visitor.get();
-  const issuer_t& issuer = signerinfo.issuer();
-
-  std::string issuer_str = std::accumulate(
-      std::begin(std::get<0>(issuer)),
-      std::end(std::get<0>(issuer)),
-      std::string(""),
-      [] (std::string lhs, const std::pair<std::string, std::string>& p) {
-        std::string s = oid_to_string(std::get<0>(p)) + std::string("=") + std::get<1>(p);
-        return lhs.empty() ? s : lhs + " " + s;
-      });
-  this->node_["issuer"] = issuer_str;
+  this->node_["issuer"] = std::get<0>(signerinfo.issuer());
 }
 
 void JsonVisitor::visit(const ContentInfo& contentinfo) {

--- a/src/PE/signature/SignatureParser.cpp
+++ b/src/PE/signature/SignatureParser.cpp
@@ -549,12 +549,11 @@ SignerInfo SignatureParser::get_signer_info(void) {
   VLOG(VDEBUG) << "Issuer: " << issuer_name;
 
   mbedtls_x509_name *name_cur;
-  mbedtls_x509_name *name_prv;
 
   name_cur = name.next;
   while( name_cur != NULL )
   {
-    name_prv = name_cur;
+    mbedtls_x509_name *name_prv = name_cur;
     name_cur = name_cur->next;
     mbedtls_free( name_prv );
   }

--- a/src/PE/signature/SignatureParser.cpp
+++ b/src/PE/signature/SignatureParser.cpp
@@ -493,7 +493,6 @@ SignerInfo SignatureParser::get_signer_info(void) {
   size_t tag;
   char oid_str[256] = { 0 };
   mbedtls_asn1_buf alg_oid;
-  mbedtls_asn1_buf content_type_oid;
 
   SignerInfo signer_info;
   int32_t version;
@@ -533,51 +532,31 @@ SignerInfo SignatureParser::get_signer_info(void) {
 
   // Name
   // ~~~~
-  std::vector<std::pair<std::string, std::string>> issuer_name;
+  mbedtls_x509_name name;
+  char buffer[1024];
+
   uint8_t* p_end = this->p_ + tag;
-  while(this->p_ < p_end) {
-    if ((ret = mbedtls_asn1_get_tag(&(this->p_), this->end_, &tag,
-            MBEDTLS_ASN1_SET | MBEDTLS_ASN1_CONSTRUCTED)) != 0) {
-      throw corrupted("Signer info corrupted");
-    }
 
-    if ((ret = mbedtls_asn1_get_tag(&(this->p_), this->end_, &tag,
-            MBEDTLS_ASN1_SEQUENCE | MBEDTLS_ASN1_CONSTRUCTED)) != 0) {
-      throw corrupted("Signer info corrupted");
-    }
+  std::memset(&name, 0, sizeof(name));
+  if ((ret = mbedtls_x509_get_name(&(this->p_), p_end, &name)) != 0) {
+    throw corrupted("Signer info corrupted");
+  }
 
-    content_type_oid.tag = *this->p_;
+  mbedtls_x509_dn_gets(buffer, sizeof(buffer), &name);
 
-    if ((ret = mbedtls_asn1_get_tag(&(this->p_), this->end_, &content_type_oid.len, MBEDTLS_ASN1_OID)) != 0) {
-      throw corrupted("Signer info corrupted");
-    }
-    content_type_oid.p = this->p_;
+  std::string issuer_name {buffer};
 
-    std::memset(oid_str, 0, sizeof(oid_str));
-    mbedtls_oid_get_numeric_string(oid_str, sizeof(oid_str), &content_type_oid);
+  VLOG(VDEBUG) << "Issuer: " << issuer_name;
 
-    VLOG(VDEBUG) << "Component ID: " << oid_str;
-    this->p_ += content_type_oid.len;
+  mbedtls_x509_name *name_cur;
+  mbedtls_x509_name *name_prv;
 
-    if ( (p_end - this->p_) < 1 ) {
-      throw corrupted("Signer info corrupted");
-    }
-
-    if (*this->p_ != MBEDTLS_ASN1_UTF8_STRING &&
-        *this->p_ != MBEDTLS_ASN1_PRINTABLE_STRING &&
-        *this->p_ != MBEDTLS_ASN1_IA5_STRING) {
-      throw corrupted("Signer info corrupted");
-    }
-
-    this->p_ += 1;
-
-    if ((ret = mbedtls_asn1_get_len(&(this->p_), this->end_, &tag)) != 0) {
-      throw corrupted("Signer info corrupted");
-    }
-    std::string name{reinterpret_cast<char*>(this->p_), tag};
-    issuer_name.emplace_back(oid_str, name);
-    VLOG(VDEBUG) << "Name: " << name;
-    this->p_ += tag;
+  name_cur = name.next;
+  while( name_cur != NULL )
+  {
+    name_prv = name_cur;
+    name_cur = name_cur->next;
+    mbedtls_free( name_prv );
   }
 
   // CertificateSerialNumber (issuer SN)

--- a/src/PE/signature/SignerInfo.cpp
+++ b/src/PE/signature/SignerInfo.cpp
@@ -67,21 +67,25 @@ std::ostream& operator<<(std::ostream& os, const SignerInfo& signer_info) {
 
   constexpr uint8_t wsize = 30;
   const issuer_t& issuer = signer_info.issuer();
+  std::string issuer_str = std::get<0>(issuer);
 
-  std::string issuer_str = std::accumulate(
-      std::begin(std::get<0>(issuer)),
-      std::end(std::get<0>(issuer)),
+  const std::vector<uint8_t>& sn = std::get<1>(issuer);;
+  std::string sn_str = std::accumulate(
+      std::begin(sn),
+      std::end(sn),
       std::string(""),
-      [] (std::string lhs, const std::pair<std::string, std::string>& p) {
-        std::string s = oid_to_string(std::get<0>(p)) + std::string("=") + std::get<1>(p);
-        return lhs.empty() ? s : lhs + " " + s;
+      [] (std::string lhs, uint8_t x) {
+        std::stringstream ss;
+        ss << std::setw(2) << std::setfill('0') << std::hex << static_cast<uint32_t>(x);
+        return lhs.empty() ? ss.str() : lhs + ":" + ss.str();
       });
+
 
   os << std::hex << std::left;
 
   os << std::setw(wsize) << std::setfill(' ') << "Version: "             << signer_info.version() << std::endl;
-  os << std::setw(wsize) << std::setfill(' ') << "Issuer: "              << issuer_str << std::endl;
-
+  os << std::setw(wsize) << std::setfill(' ') << "Issuer Serial Number: "<< sn_str << std::endl;
+  os << std::setw(wsize) << std::setfill(' ') << "Issuer DN: "           << issuer_str << std::endl;
   os << std::setw(wsize) << std::setfill(' ') << "Digest Algorithm: "    << oid_to_string(signer_info.digest_algorithm()) << std::endl;
   os << std::setw(wsize) << std::setfill(' ') << "Signature algorithm: " << oid_to_string(signer_info.signature_algorithm()) << std::endl;
 

--- a/src/PE/signature/SignerInfo.cpp
+++ b/src/PE/signature/SignerInfo.cpp
@@ -16,6 +16,7 @@
 #include <iomanip>
 #include <type_traits>
 #include <numeric>
+#include <sstream>
 
 #include "LIEF/PE/signature/OIDToString.hpp"
 #include "LIEF/PE/signature/SignerInfo.hpp"

--- a/src/PE/signature/SignerInfo.cpp
+++ b/src/PE/signature/SignerInfo.cpp
@@ -85,7 +85,7 @@ std::ostream& operator<<(std::ostream& os, const SignerInfo& signer_info) {
   os << std::hex << std::left;
 
   os << std::setw(wsize) << std::setfill(' ') << "Version: "             << signer_info.version() << std::endl;
-  os << std::setw(wsize) << std::setfill(' ') << "Issuer Serial Number: "<< sn_str << std::endl;
+  os << std::setw(wsize) << std::setfill(' ') << "Serial Number: "       << sn_str << std::endl;
   os << std::setw(wsize) << std::setfill(' ') << "Issuer DN: "           << issuer_str << std::endl;
   os << std::setw(wsize) << std::setfill(' ') << "Digest Algorithm: "    << oid_to_string(signer_info.digest_algorithm()) << std::endl;
   os << std::setw(wsize) << std::setfill(' ') << "Signature algorithm: " << oid_to_string(signer_info.signature_algorithm()) << std::endl;


### PR DESCRIPTION
This makes it so that the SignerInfo issuer field has the same
format as the issuer fields in each x509 cert, so the two can
be more easily compared.

Also, this commit adds '0x' in front of the Data Directory
RVAs and sizes to make it more clear that the values are printed
in hex.