### PR TITLE
Expose the raw bytes backing each embedded PE Authenticode cert

### DIFF
--- a/api/python/PE/objects/signature/pyx509.cpp
+++ b/api/python/PE/objects/signature/pyx509.cpp
@@ -72,6 +72,9 @@ void create<x509>(py::module& m) {
         },
         "Subject informations")
 
+    .def_property_readonly("raw",
+        &x509::raw,
+        "The raw bytes associated with this x509 cert (DER encoded)")
 
     .def("__str__",
         [] (const x509& x509_crt)

--- a/include/LIEF/PE/signature/x509.hpp
+++ b/include/LIEF/PE/signature/x509.hpp
@@ -65,6 +65,9 @@ class LIEF_API x509 : public Object {
   //! @brief Subject informations
   std::string subject(void) const;
 
+  //! @brief The raw x509 bytes (DER encoded)
+  std::vector<uint8_t> raw(void) const;
+
   virtual void accept(Visitor& visitor) const override;
 
   virtual ~x509(void);

--- a/src/PE/signature/x509.cpp
+++ b/src/PE/signature/x509.cpp
@@ -108,6 +108,9 @@ std::string x509::subject(void) const {
   return {buffer};
 }
 
+std::vector<uint8_t> x509::raw(void) const {
+  return {this->x509_cert_->raw.p, this->x509_cert_->raw.p + this->x509_cert_->raw.len};
+}
 
 void x509::accept(Visitor& visitor) const {
   visitor.visit(*this);


### PR DESCRIPTION
This makes it trivial to extract the embedded certificates, which is really useful