### PR TITLE
Build manylinux1 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,60 +24,31 @@ matrix:
         #    ]
 
 
-        # Linux gcc 5.0 - Python 3.5
-        - os: linux
-          dist: trusty
-          compiler: gcc
-          addons:
-            apt:
-              sources: ['ubuntu-toolchain-r-test', 'deadsnakes']
-              packages: ['g++-5', 'gcc-5', 'ccache', 'python3.5-dev']
+        - sudo: required
+          services:
+            - docker
           env: >
             [
-            CXX_COMPILER=g++-5                         ,
-            C_COMPILER=gcc-5                           ,
-            PYTHON_VERSION=3.5                         ,
-            PYTHON_INCLUDE_DIR=/usr/include/python3.5m ,
-            PYTHON_LIBRARY=/usr/lib/libpython3.5m.so   ,
-            PYTHON_BINARY=/usr/bin/python3.5           ,
+            PYTHON_VERSION=3.5                                 ,
+            PYTHON_BINARY=/opt/python/cp35-cp35m/bin/python3.5 ,
             ]
 
-
-        # Linux gcc 6 - Python 3.6
-        - os: linux
-          dist: trusty
-          compiler: gcc
-          addons:
-            apt:
-              sources: ['ubuntu-toolchain-r-test', 'deadsnakes']
-              packages: ['g++-6', 'gcc-6', 'ccache', 'python3.6-dev']
+        - sudo: required
+          services:
+            - docker
           env: >
             [
-            CXX_COMPILER=g++-6                         ,
-            C_COMPILER=gcc-6                           ,
-            PYTHON_VERSION=3.6                         ,
-            PYTHON_INCLUDE_DIR=/usr/include/python3.6m ,
-            PYTHON_LIBRARY=/usr/lib/libpython3.6m.so   ,
-            PYTHON_BINARY=/usr/bin/python3.6           ,
+            PYTHON_VERSION=3.6                                 ,
+            PYTHON_BINARY=/opt/python/cp36-cp36m/bin/python3.6 ,
             ]
 
-
-        # Linux gcc 6 - Python 3.7
-        - os: linux
-          dist: xenial
-          compiler: gcc
-          addons:
-            apt:
-              sources: ['ubuntu-toolchain-r-test', 'deadsnakes']
-              packages: ['g++-6', 'gcc-6', 'ccache', 'python3.7', 'python3.7-dev']
+        - sudo: required
+          services:
+            - docker
           env: >
             [
-            CXX_COMPILER=g++-6                         ,
-            C_COMPILER=gcc-6                           ,
-            PYTHON_VERSION=3.7                         ,
-            PYTHON_INCLUDE_DIR=/usr/include/python3.7m ,
-            PYTHON_LIBRARY=/usr/lib/libpython3.7m.so   ,
-            PYTHON_BINARY=/usr/bin/python3.7           ,
+            PYTHON_VERSION=3.7                                 ,
+            PYTHON_BINARY=/opt/python/cp37-cp37m/bin/python3.7 ,
             ]
 
         # OSX 10.11 - xcode 7.3 - Python 2.7
@@ -97,8 +68,8 @@ matrix:
           compiler: clang
           env: >
             [
-            CXX_COMPILER=clang++ ,
-            C_COMPILER=clang     ,
+            CXX=clang++ ,
+            CC=clang     ,
             PYTHON_VERSION=3.5   ,
             ]
 
@@ -109,8 +80,8 @@ matrix:
           compiler: clang
           env: >
             [
-            CXX_COMPILER=clang++ ,
-            C_COMPILER=clang     ,
+            CXX=clang++ ,
+            CC=clang     ,
             PYTHON_VERSION=3.6   ,
             ]
 
@@ -121,8 +92,8 @@ matrix:
           compiler: clang
           env: >
             [
-            CXX_COMPILER=clang++ ,
-            C_COMPILER=clang     ,
+            CXX=clang++ ,
+            CC=clang     ,
             PYTHON_VERSION=3.7   ,
             ]
 
@@ -152,10 +123,7 @@ cache:
   - build/api/python/pybind11-prefix
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update -q; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install python-setuptools; fi
-  - export CC="$C_COMPILER"
-  - export CXX="$CXX_COMPILER"
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then docker build -t lief/manylinux1_x86_64 .; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PREFIX="/usr/local"; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install ccache; fi
@@ -186,7 +154,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$PYTHON_VERSION" == "3.7" ]]; then export PYTHON_INCLUDE_DIR=$(pyenv root)/versions/3.7.0/include/python3.7m  ;fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$PYTHON_VERSION" == "3.7" ]]; then export PYTHON_LIBRARY=$(pyenv root)/versions/3.7.0/lib/libpython3.7m.dylib ;fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$PYTHON_VERSION" == "3.7" ]]; then export PYTHON_BINARY=$(pyenv root)/versions/3.7.0/bin/python3.7            ;fi
-
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $PYTHON_BINARY -m pip install --upgrade pip        ;fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then $PYTHON_BINARY -m pip install --upgrade setuptools ;fi
 
@@ -196,29 +163,13 @@ install:
   - if [ "$GCOV" == "ON" ]; then tar xf lcov_1.13.orig.tar.gz; fi
   - if [ "$GCOV" == "ON" ]; then sudo make -C lcov-1.13/ install; fi
 
-  # Setup CMake 3.1 for Linux
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget --no-check-certificate http://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz   ;fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xzf cmake-3.7.2-Linux-x86_64.tar.gz                                                  ;fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$PWD/cmake-3.7.2-Linux-x86_64/bin:$PATH                                       ;fi
-
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py   ;fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H $PYTHON_BINARY ./get-pip.py ;fi
-
 script:
-  - export CC=$C_COMPILER
-  - export CXX=$CXX_COMPILER
-
-  - sudo $PYTHON_BINARY -m pip install setuptools
-  - sudo $PYTHON_BINARY -m pip install wheel
-  - sudo $PYTHON_BINARY -m pip install --upgrade setuptools
-  - sudo $PYTHON_BINARY -m pip install --upgrade pip
-  - $PYTHON_BINARY ./setup.py --lief-test --sdk build -j8 bdist_wheel
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run --rm -e PYTHON_BINARY=$PYTHON_BINARY -v $HOME/.ccache:/ccache -v $(pwd):/src lief/manylinux1_x86_64 bash -c 'CCACHE_DIR=/ccache $PYTHON_BINARY setup.py --lief-test --sdk build -j8 bdist_wheel --dist-dir wheel_stage && auditwheel repair -w dist --plat manylinux1_x86_64 wheel_stage/*.whl '; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo $PYTHON_BINARY -m pip install -U pip setuptools wheel && $PYTHON_BINARY ./setup.py --lief-test --sdk build -j8 bdist_wheel; fi
 
 after_success:
   - make package
-  - sudo $PYTHON_BINARY -m pip install setuptools requests mako
-  - sudo $PYTHON_BINARY -m pip install wheel
-  - sudo $PYTHON_BINARY -m pip install --upgrade setuptools
+  - sudo $PYTHON_BINARY -m pip install --upgrade setuptools requests mako wheel
   - cd api/python
   - $PYTHON_BINARY setup.py bdist_egg
   - if [[ -z "$TRAVIS_TAG" ]]; then $PYTHON_BINARY setup.py sdist --dev --formats=zip ;fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/pypa/manylinux1_x86_64:latest
+
+RUN /opt/python/cp37-cp37m/bin/pip install cmake==3.13.3
+ENV PATH=$PATH:/opt/python/cp37-cp37m/bin/
+
+RUN curl -L https://github.com/squeaky-pl/centos-devtools/releases/download/6.3/gcc-6.3.0-binutils-2.27-x86_64.tar.bz2 | tar -C / -xj
+ENV CC=/opt/devtools-6.3/bin/gcc
+ENV CXX=/opt/devtools-6.3/bin/g++
+ENV CXXFLAGS=-static-libstdc++
+
+WORKDIR /src

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,29 +106,30 @@ endif()
 
 # Fuzzing
 # =======
-if(UNIX AND NOT APPLE)
+ if(UNIX AND NOT APPLE)
 
-  set(MELKOR_VERSION master)
-  set(MELKOR_SHA256 SHA256=8d8115117e87ee1fad81cb09e53524f7bee9a4803632ae3b0b1cfbb66c86a6f4)
-  set(MELKOR_URL "${THIRD_PARTY_DIRECTORY}/Melkor_ELF_Fuzzer-${MELKOR_VERSION}.zip" CACHE STRING "URL to the Melkor package")
+   set(MELKOR_VERSION master)
+   set(MELKOR_SHA256 SHA256=8d8115117e87ee1fad81cb09e53524f7bee9a4803632ae3b0b1cfbb66c86a6f4)
+   set(MELKOR_URL "${THIRD_PARTY_DIRECTORY}/Melkor_ELF_Fuzzer-${MELKOR_VERSION}.zip" CACHE STRING "URL to the Melkor package")
 
-  set(MELKOR_PREFIX      "${CMAKE_CURRENT_BINARY_DIR}/Melkor")
-  set(MELKOR_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/Melkor")
-  ExternalProject_Add(MELKOR
-   PREFIX            ${MELKOR_PREFIX}
-   URL               ${MELKOR_URL}
-   URL_HASH          ${MELKOR_SHA256}
-   INSTALL_DIR       ${MELKOR_INSTALL_DIR}
-   UPDATE_COMMAND    ""
-   CONFIGURE_COMMAND ""
-   INSTALL_COMMAND   ""
-   BUILD_COMMAND     make clean && make
-   BUILD_IN_SOURCE   ON)
+   set(MELKOR_PREFIX      "${CMAKE_CURRENT_BINARY_DIR}/Melkor")
+   set(MELKOR_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/Melkor")
+   ExternalProject_Add(MELKOR
+    PREFIX            ${MELKOR_PREFIX}
+    URL               ${MELKOR_URL}
+    URL_HASH          ${MELKOR_SHA256}
+    INSTALL_DIR       ${MELKOR_INSTALL_DIR}
+    UPDATE_COMMAND    ""
+    CONFIGURE_COMMAND ""
+    INSTALL_COMMAND   ""
+    BUILD_COMMAND     make clean && make
+    BUILD_IN_SOURCE   ON
+    PATCH_COMMAND     patch -p1 < ${THIRD_PARTY_DIRECTORY}/melkor-makefile-old-find.patch)
 
-  ExternalProject_get_property(MELKOR SOURCE_DIR)
-  set(MELKOR_BINARY "${SOURCE_DIR}/melkor")
-  message(STATUS "${MELKOR_BINARY}")
-endif()
+   ExternalProject_get_property(MELKOR SOURCE_DIR)
+   set(MELKOR_BINARY "${SOURCE_DIR}/melkor")
+   message(STATUS "${MELKOR_BINARY}")
+ endif()
 
 # Tests
 # =====

--- a/tests/elf/add_content.py
+++ b/tests/elf/add_content.py
@@ -14,7 +14,7 @@ import lief
 from lief.ELF import Section
 
 from unittest import TestCase
-from utils import get_sample
+from utils import get_sample, get_compiler
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 STUB = lief.parse(os.path.join(CURRENT_DIRECTORY, "hello_lief.bin"))
@@ -62,11 +62,7 @@ class TestAddContent(TestCase):
         self.libadd_so  = os.path.join(self.tmp_dir, "libadd.so")
         self.binadd_bin = os.path.join(self.tmp_dir, "binadd.bin")
 
-        # self.compiler = shutil.which(os.environ.get('CC', 'cc')) # only for Python > 3
-        self.compiler = '/usr/bin/cc'
-        if self.compiler is None:
-            self.logger.error("Unable to find a compiler")
-            sys.exit(0)
+        self.compiler = get_compiler()
 
         self.logger.debug("Compiler: {}".format(self.compiler))
 

--- a/tests/elf/add_section.py
+++ b/tests/elf/add_section.py
@@ -14,7 +14,7 @@ import lief
 from lief.ELF import Section
 
 from unittest import TestCase
-from utils import get_sample
+from utils import get_sample, has_recent_glibc
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 STUB = lief.parse(os.path.join(CURRENT_DIRECTORY, "hello_lief.bin"))
@@ -27,6 +27,7 @@ class TestAddSection(TestCase):
 
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_simple(self):
         sample_path = get_sample('ELF/ELF64_x86-64_binary_ls.bin')
         output      = os.path.join(self.tmp_dir, "ls.section")
@@ -55,6 +56,7 @@ class TestAddSection(TestCase):
 
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_gcc(self):
         sample_path = get_sample('ELF/ELF64_x86-64_binary_gcc.bin')
         output      = os.path.join(self.tmp_dir, "gcc.section")

--- a/tests/elf/add_segment.py
+++ b/tests/elf/add_segment.py
@@ -16,7 +16,7 @@ from lief import Logger
 #Logger.set_level(lief.LOGGING_LEVEL.DEBUG)
 
 from unittest import TestCase
-from utils import get_sample
+from utils import get_sample, has_recent_glibc
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
@@ -26,8 +26,8 @@ class TestAddSegment(TestCase):
         self.tmp_dir = tempfile.mkdtemp(suffix='_lief_test_add_segment')
         self.logger.debug("temp dir: {}".format(self.tmp_dir))
 
-
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_simple(self):
         sample_path = get_sample('ELF/ELF64_x86-64_binary_ls.bin')
         stub        = lief.parse(os.path.join(CURRENT_DIRECTORY, "hello_lief.bin"))
@@ -54,6 +54,7 @@ class TestAddSegment(TestCase):
 
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_gcc(self):
         sample_path = get_sample('ELF/ELF64_x86-64_binary_gcc.bin')
         stub        = lief.parse(os.path.join(CURRENT_DIRECTORY, "hello_lief.bin"))

--- a/tests/elf/elf_test.py
+++ b/tests/elf/elf_test.py
@@ -17,7 +17,7 @@ Logger.set_level(lief.LOGGING_LEVEL.WARNING)
 from subprocess import Popen
 
 from unittest import TestCase
-from utils import get_sample
+from utils import get_sample, has_recent_glibc
 
 class TestELF(TestCase):
 
@@ -83,6 +83,7 @@ class TestELF(TestCase):
         self.assertFalse(gnu_hash.check("foofdsfdsfds"))
         self.assertFalse(gnu_hash.check("fazertrvkdfsrezklqpfjeopqdi"))
 
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_permutation(self):
         samples = [
                 "ELF/ELF64_x86-64_binary_ls.bin",

--- a/tests/elf/modify_relocations.py
+++ b/tests/elf/modify_relocations.py
@@ -14,7 +14,7 @@ import lief
 from lief.ELF import Section
 
 from unittest import TestCase
-from utils import get_sample
+from utils import get_sample, has_recent_glibc
 
 class TestRelocations(TestCase):
     def setUp(self):
@@ -24,6 +24,7 @@ class TestRelocations(TestCase):
 
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_simple(self):
         sample_path = get_sample('ELF/ELF64_x86-64_binary_ls.bin')
         output      = os.path.join(self.tmp_dir, "ls.relocation")

--- a/tests/elf/remove_section.py
+++ b/tests/elf/remove_section.py
@@ -14,7 +14,7 @@ import lief
 from lief.ELF import Section
 
 from unittest import TestCase
-from utils import get_sample
+from utils import get_sample, has_recent_glibc
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
@@ -24,8 +24,8 @@ class TestRemoveSection(TestCase):
         self.tmp_dir = tempfile.mkdtemp(suffix='_lief_test_section')
         self.logger.debug("temp dir: {}".format(self.tmp_dir))
 
-
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_simple(self):
         sample_path = get_sample('ELF/ELF64_x86-64_binary_ls.bin')
         output      = os.path.join(self.tmp_dir, "ls.section")

--- a/tests/elf/replace_segment.py
+++ b/tests/elf/replace_segment.py
@@ -16,7 +16,7 @@ from lief import Logger
 #Logger.set_level(lief.LOGGING_LEVEL.DEBUG)
 
 from unittest import TestCase
-from utils import get_sample
+from utils import get_sample, has_recent_glibc
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
@@ -28,6 +28,7 @@ class TestAddSegment(TestCase):
 
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_simple(self):
         sample_path = get_sample('ELF/ELF64_x86-64_binary_ls.bin')
         stub        = lief.parse(os.path.join(CURRENT_DIRECTORY, "hello_lief.bin"))
@@ -58,6 +59,7 @@ class TestAddSegment(TestCase):
 
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_gcc(self):
         sample_path = get_sample('ELF/ELF64_x86-64_binary_gcc.bin')
         stub        = lief.parse(os.path.join(CURRENT_DIRECTORY, "hello_lief.bin"))
@@ -88,6 +90,7 @@ class TestAddSegment(TestCase):
 
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
+    @unittest.skipUnless(has_recent_glibc(), "Need a recent GLIBC version")
     def test_ssh(self):
         stub        = lief.parse(os.path.join(CURRENT_DIRECTORY, "hello_lief.bin"))
         output      = os.path.join(self.tmp_dir, "ssh.replace_segment")

--- a/tests/elf/test_bin2lib.py
+++ b/tests/elf/test_bin2lib.py
@@ -10,6 +10,8 @@ import shutil
 import sys
 from collections import namedtuple
 
+from utils import get_compiler
+
 class CommandResult(object):
     def __init__(self, output, error, retcode, process=None):
         self.output = output
@@ -123,9 +125,7 @@ class TestBin2Lib(unittest.TestCase):
         with open(libaddc, 'w') as f:
             f.write(LIBADD)
 
-        #compiler = os.getenv("CC", "cc")
-        #compiler = shutil.which(compiler)
-        compiler = "/usr/bin/cc"
+        compiler = get_compiler()
 
         # Compile libadd
         r = self.run_cmd("{compiler} -Wl,--export-dynamic -mcmodel=large -fPIE -pie -o {output} {input}".format(
@@ -189,9 +189,7 @@ class TestBin2Lib(unittest.TestCase):
         with open(libaddc, 'w') as f:
             f.write(LIBADD)
 
-        #compiler = os.getenv("CC", "cc")
-        #compiler = shutil.which(compiler)
-        compiler = "/usr/bin/cc"
+        compiler = get_compiler()
 
         # Compile libadd
         r = self.run_cmd("{compiler} -Wl,--export-dynamic -mcmodel=large -fPIE -pie -o {output} {input}".format(
@@ -247,9 +245,7 @@ class TestBin2Lib(unittest.TestCase):
         with open(libaddc, 'w') as f:
             f.write(LIBADD)
 
-        #compiler = os.getenv("CC", "cc")
-        #compiler = shutil.which(compiler)
-        compiler = "/usr/bin/cc"
+        compiler = get_compiler()
 
         # Compile libadd
         r = self.run_cmd("{compiler} -Wl,--export-dynamic -mcmodel=large -fPIE -pie -o {output} {input}".format(

--- a/tests/elf/test_dynamic.py
+++ b/tests/elf/test_dynamic.py
@@ -14,7 +14,7 @@ Logger.set_level(lief.LOGGING_LEVEL.INFO)
 
 from subprocess import Popen
 from unittest import TestCase
-from utils import get_sample
+from utils import get_sample, get_compiler
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 STUB = lief.parse(os.path.join(CURRENT_DIRECTORY, "hello_lief.bin"))
@@ -63,12 +63,7 @@ class LibAddSample(object):
         self.libadd_so  = os.path.join(self.tmp_dir, "libadd.so")
         self.binadd_bin = os.path.join(self.tmp_dir, "binadd.bin")
 
-        self.compiler = '/usr/bin/cc'
-
-        if self.compiler is None:
-            self.logger.error("Unable to find a compiler")
-            sys.exit(0)
-
+        self.compiler = get_compiler()
         self.logger.debug("Compiler: {}".format(self.compiler))
 
         with open(self.binadd_path, 'w') as f:

--- a/tests/elf/test_static.py
+++ b/tests/elf/test_static.py
@@ -13,6 +13,8 @@ Logger.set_level(lief.LOGGING_LEVEL.INFO)
 from subprocess import Popen
 from unittest import TestCase
 
+from utils import get_compiler
+
 BINADD_C = """\
 #include <stdio.h>
 #include <stdlib.h>
@@ -51,12 +53,7 @@ class LibAddSample(object):
         self.binadd_obj = os.path.join(self.tmp_dir, "binadd.o")
         self.binadd_bin = os.path.join(self.tmp_dir, "binadd.exe")
 
-        self.compiler = '/usr/bin/cc'
-
-        if self.compiler is None:
-            self.logger.error("Unable to find a compiler")
-            sys.exit(0)
-
+        self.compiler = get_compiler()
         self.logger.debug("Compiler: {}".format(self.compiler))
 
         with open(self.binadd_path, 'w') as f:

--- a/tests/utils.py.in
+++ b/tests/utils.py.in
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import os
+import re
+import subprocess
 
 def get_sample(filename):
     fullpath = os.path.join("@LIEF_SAMPLES_DIRECTORY@", filename)
@@ -9,3 +11,23 @@ def get_sample(filename):
 
     return fullpath
 
+def get_compiler():
+    compiler = os.getenv("CC", "/usr/bin/cc")
+    if not os.path.exists(compiler):
+        raise RuntimeError("Unable to find a compiler")
+    return compiler
+
+
+def has_recent_glibc():
+    """Check if we have at least GLIBC 2.17"""
+    try:
+        out = subprocess.check_output(["ldd", "--version"]).decode("ascii")
+        version_str = re.search(" (\d\.\d+)\n", out).group(1)
+        major, minor = version_str.split(".")
+    except (OSError, AttributeError):
+        pass
+    else:
+        if int(major) == 2 and int(minor) >= 17:
+            return True
+
+    return False

--- a/third-party/melkor-makefile-old-find.patch
+++ b/third-party/melkor-makefile-old-find.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index d32d874..1b155b4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -49,8 +49,8 @@ envtools:
+ install:
+ 	install $(OUTPUT) $(INSTALLPATH)
+ clean:
+-	find  $(SRC) -type f -executable -exec rm {} \;
+-	find  $(TEMPL_SRC) -type f -executable -exec rm {} \;
++	find  $(SRC) -type f -perm /111 -exec rm {} \;
++	find  $(TEMPL_SRC) -type f -perm /111 -exec rm {} \;
+ 	rm -f $(TEMPL_SRC)/*.o
+ 	rm -f $(TEMPL_SRC)/*.so
+ 	rm -f $(SRC)/*.o


### PR DESCRIPTION
Build `manylinux1` wheels using the `manylinux1_x86_64` Docker image. The Linux builds is executed in Docker and the produced `.whl` files are passed to `auditwheel repair` to correctly label them and vendor external dependencies inside the wheels.

A few notes on the changes:

- The Melkor ELF fuzzer is excluded from the build as its Makefile calls `find` with the `-executable` option which is not supported on CentOS 5. Given that the project seems fairly inactive and a PR for this might not get merged, I just patch the `Makefile` during the build process.
- I had to add a check to see if we have GLIBC 2.17 and skip a few tests which have been compiled  on a more recent platform as CentOS 5 does not have the required symbols. Either the tests should be recompiled on the `manylinux` Docker image or we could copy the resulting LIEF wheel out of the Docker container, install it on the host and run the test suite there.
- The builds seem slowerr in Docker. I've added a bind mount volume for the `ccache` data I'm not sure it works because I have not seen any speedup in build times.
- The Codacy check flags the `FROM` field in the `Dockerfile` for not using a specific tag. I think in this case it is actually preferable to not use a tag so that we always pick up the most recent build tools and the native library versions won't change in the image. Besides, the only tag on the image is `latest`. I don't know how to suppress the Codacy check though.

Resolves: #325 