### PR TITLE
Fix missing build folder when building with Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ install:
   - if [ "$GCOV" == "ON" ]; then sudo make -C lcov-1.13/ install; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run --name lief_$PYTHON_VERSION -e PYTHON_BINARY=$PYTHON_BINARY -e CCACHE_DIR=/ccache -v $HOME/.ccache:/ccache lief/manylinux1_x86_64 bash -c '$PYTHON_BINARY setup.py --lief-test --sdk build -j8 bdist_wheel --dist-dir wheel_stage && auditwheel repair -w dist --plat manylinux1_x86_64 wheel_stage/*.whl ' && docker cp lief_$PYTHON_VERSION:/src/dist/ .; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run --name lief_$PYTHON_VERSION -e PYTHON_BINARY=$PYTHON_BINARY -e CCACHE_DIR=/ccache -v $HOME/.ccache:/ccache lief/manylinux1_x86_64 bash -c '$PYTHON_BINARY setup.py --lief-test --sdk build -j8 bdist_wheel --dist-dir wheel_stage && auditwheel repair -w dist --plat manylinux1_x86_64 wheel_stage/*.whl ' && docker cp lief_$PYTHON_VERSION:/src/dist/ . && docker cp lief_$PYTHON_VERSION:/src/build/ .; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo $PYTHON_BINARY -m pip install -U pip setuptools wheel && $PYTHON_BINARY ./setup.py --lief-test --sdk build -j8 bdist_wheel; fi
 
 after_success:


### PR DESCRIPTION
After finishing the build inside Docker we need the build directory from
the container to be able to deploy the built artifacts with deploy.sh.

I tested the deploy script by "simulating" a Travis environment in a container, setting all expected environment variables as needed. It successfully got to the part where it executes the `make_index.py` script.

Resolves: #343 