### PR TITLE
Use the right Python interpreter for Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,6 +169,7 @@ script:
 
 after_success:
   - make package
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PYTHON_BINARY=python3; fi
   - sudo $PYTHON_BINARY -m pip install --upgrade setuptools requests mako wheel
   - cd api/python
   - $PYTHON_BINARY setup.py bdist_egg


### PR DESCRIPTION
The Dockerized .travis.yml builds attempt to invoke the interpreter in
the PYTHON_BINARY environment variable, which is only valid inside the
Docker image. To fix this, override the variable on Linux for tasks
which require the host's Python interpreter.