### PR TITLE
Expose raw bytes of Authenticode-related structures

### DIFF
--- a/api/python/PE/objects/signature/pyAuthenticatedAttributes.cpp
+++ b/api/python/PE/objects/signature/pyAuthenticatedAttributes.cpp
@@ -58,6 +58,10 @@ void create<AuthenticatedAttributes>(py::module& m) {
         },
         "Return an URL to website with more information about the signer")
 
+    .def_property_readonly("raw",
+        &AuthenticatedAttributes::raw,
+        "Return the raw bytes associated with the AuthenticatedAttributes")
+
     .def("__str__",
         [] (const AuthenticatedAttributes& authenticated_attributes)
         {

--- a/api/python/PE/objects/signature/pyContentInfo.cpp
+++ b/api/python/PE/objects/signature/pyContentInfo.cpp
@@ -52,6 +52,9 @@ void create<ContentInfo>(py::module& m) {
         &ContentInfo::digest,
         "The digest")
 
+    .def_property_readonly("raw",
+        &ContentInfo::raw,
+        "Return the raw bytes associated with the ContentInfo")
 
     .def("__str__",
         [] (const ContentInfo& content_info)

--- a/include/LIEF/PE/signature/AuthenticatedAttributes.hpp
+++ b/include/LIEF/PE/signature/AuthenticatedAttributes.hpp
@@ -49,6 +49,9 @@ class LIEF_API AuthenticatedAttributes : public Object {
   //! @brief Return an URL to website with more information about the signer
   const std::string& more_info(void) const;
 
+  //! @brief Return the raw bytes associated with the AuthenticatedAttributes
+  const std::vector<uint8_t>& raw(void) const;
+
   virtual void accept(Visitor& visitor) const override;
 
   virtual ~AuthenticatedAttributes(void);
@@ -62,6 +65,7 @@ class LIEF_API AuthenticatedAttributes : public Object {
 
   std::u16string program_name_;
   std::string    more_info_;
+  std::vector<uint8_t> raw_;
 
 };
 

--- a/include/LIEF/PE/signature/ContentInfo.hpp
+++ b/include/LIEF/PE/signature/ContentInfo.hpp
@@ -50,6 +50,9 @@ class LIEF_API ContentInfo : public Object {
   //! @brief The digest
   const std::vector<uint8_t>& digest(void) const;
 
+  //! @brief Return the raw bytes associated with the ContentInfo
+  const std::vector<uint8_t>& raw(void) const;
+
   virtual void accept(Visitor& visitor) const override;
 
   virtual ~ContentInfo(void);
@@ -64,7 +67,7 @@ class LIEF_API ContentInfo : public Object {
 
   oid_t digest_algorithm_; // algorithm used to hash the file (should match Signature::digest_algorithms_)
   std::vector<uint8_t> digest_; //hash value
-
+  std::vector<uint8_t> raw_; // raw bytes
 
 };
 

--- a/src/PE/signature/AuthenticatedAttributes.cpp
+++ b/src/PE/signature/AuthenticatedAttributes.cpp
@@ -44,6 +44,10 @@ const std::string& AuthenticatedAttributes::more_info(void) const {
   return this->more_info_;
 }
 
+const std::vector<uint8_t>& AuthenticatedAttributes::raw(void) const {
+  return this->raw_;
+}
+
 void AuthenticatedAttributes::accept(Visitor& visitor) const {
   visitor.visit(*this);
 }

--- a/src/PE/signature/ContentInfo.cpp
+++ b/src/PE/signature/ContentInfo.cpp
@@ -44,6 +44,9 @@ const std::vector<uint8_t>& ContentInfo::digest(void) const {
   return this->digest_;
 }
 
+const std::vector<uint8_t>& ContentInfo::raw(void) const {
+  return this->raw_;
+}
 
 void ContentInfo::accept(Visitor& visitor) const {
   visitor.visit(*this);

--- a/src/PE/signature/SignatureParser.cpp
+++ b/src/PE/signature/SignatureParser.cpp
@@ -188,6 +188,9 @@ ContentInfo SignatureParser::parse_content_info(void) {
     throw corrupted("Signature corrupted");
   }
 
+  // Save off raw now so that it covers everything else in the ContentInfo
+  content_info.raw_ = {this->p_, this->p_ + tag};
+
   // SpcAttributeTypeAndOptionalValue
   // |_ SPC_PE_IMAGE_DATAOBJ
   // |_ SpcPeImageData
@@ -350,6 +353,8 @@ AuthenticatedAttributes SignatureParser::get_authenticated_attributes(void) {
           MBEDTLS_ASN1_CONTEXT_SPECIFIC | MBEDTLS_ASN1_CONSTRUCTED)) != 0) {
     throw corrupted("Authenticated attributes corrupted");
   }
+
+  authenticated_attributes.raw_ = {this->p_, this->p_ + tag};
 
   uint8_t* p_end = this->p_ + tag;
   while(this->p_ < p_end) {


### PR DESCRIPTION
Part of Authenticode verification consists of:
 - Comparing the computed Authenticode hash to the digest
   stored in the ContentInfo section
 - Comparing hash(ContentInfo) to the digest stored in the
   AuthenticatedAttributes section
 - Verifying signed(hash(AuthenticatedAttributes)) using a
   certificate identified by the issuer and serial number
   specified in the SignerInfo section

This commit makes it so that the raw bytes needed to
calculate hash(ContentInfo) and hash(AuthenticatedAttributes)
are available for use.

We could compute the hashes in LIEF and just make those
available instead, or we could perform the validation
outright and pass this info back through a boolean value
or something... Just exposing the raw bytes and letting
the application perform this check (if needed) is simpler,
though (especially for me, since I'm not familiar with a
lot of the C++ features used in this code base).