### PR TITLE
Expose raw bytes of Authenticode-related structures and other improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,10 @@ if (CMAKE_BUILD_TYPE MATCHES Debug AND WINDOWS)
   )
 endif()
 
+if (CMAKE_BUILD_TYPE MATCHES Debug AND UNIX)
+  target_compile_options(LIB_LIEF PRIVATE -g -O0)
+endif()
+
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(LIB_LIEF PRIVATE -DLIEF_EXPORTS)
 else()
@@ -244,7 +248,7 @@ endif()
 
 
 # VDEX part
-# =========
+# =========
 if (LIEF_VDEX)
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/VDEX/CMakeLists.txt)
   set(ENABLE_VDEX_SUPPORT 1)
@@ -254,7 +258,7 @@ endif()
 
 
 # ART part
-# ========
+# ========
 if (LIEF_ART)
   include(${CMAKE_CURRENT_SOURCE_DIR}/src/ART/CMakeLists.txt)
   set(ENABLE_ART_SUPPORT 1)
@@ -267,7 +271,7 @@ endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/platforms/CMakeLists.txt)
 
 # LIEF includes
-# =============
+# =============
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/include/LIEF/version.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/include/LIEF/version.h"
@@ -336,6 +340,16 @@ set_property(TARGET LIB_LIEF PROPERTY CXX_VISIBILITY_PRESET     hidden)
 
 target_compile_definitions(LIB_LIEF PUBLIC -D_GLIBCXX_USE_CXX11_ABI=1)
 
+# Enable support for MD2 and MD4 for parsing the Authenticode sigs
+# of older executables. Also, some older signed executables use certs
+# with the SpcSpAgencyInfo Critical Extension, which mbed TLS doesn't
+# support, so set MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION to
+# have it skip this extension.
+add_definitions(
+  -DMBEDTLS_MD2_C
+  -DMBEDTLS_MD4_C
+  -DMBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+)
 
 
 # ASAN - LSAN - TSAN - USAN
@@ -494,7 +508,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND UNIX)
 endif()
 
 # Installation
-# ============
+# ============
 
 install(TARGETS LIB_LIEF
   ARCHIVE

--- a/api/python/PE/objects/signature/pyAuthenticatedAttributes.cpp
+++ b/api/python/PE/objects/signature/pyAuthenticatedAttributes.cpp
@@ -58,6 +58,10 @@ void create<AuthenticatedAttributes>(py::module& m) {
         },
         "Return an URL to website with more information about the signer")
 
+    .def_property_readonly("raw",
+        &AuthenticatedAttributes::raw,
+        "Return the raw bytes associated with the AuthenticatedAttributes")
+
     .def("__str__",
         [] (const AuthenticatedAttributes& authenticated_attributes)
         {

--- a/api/python/PE/objects/signature/pyContentInfo.cpp
+++ b/api/python/PE/objects/signature/pyContentInfo.cpp
@@ -52,6 +52,9 @@ void create<ContentInfo>(py::module& m) {
         &ContentInfo::digest,
         "The digest")
 
+    .def_property_readonly("raw",
+        &ContentInfo::raw,
+        "Return the raw bytes associated with the ContentInfo")
 
     .def("__str__",
         [] (const ContentInfo& content_info)

--- a/api/python/PE/objects/signature/pySignerInfo.cpp
+++ b/api/python/PE/objects/signature/pySignerInfo.cpp
@@ -41,9 +41,12 @@ void create<SignerInfo>(py::module& m) {
         "Should be 1")
 
     .def_property_readonly("issuer",
-        &SignerInfo::issuer,
+        [] (const SignerInfo& object) {
+          const issuer_t& issuer = object.issuer();
+          return std::pair<py::object, std::vector<uint8_t>>{safe_string_converter(std::get<0>(issuer)), std::get<1>(issuer)};
+        },
         "Issuer and serial number",
-        py::return_value_policy::reference)
+        py::return_value_policy::copy)
 
     .def_property_readonly("digest_algorithm",
         &SignerInfo::digest_algorithm,

--- a/include/LIEF/PE/signature/AuthenticatedAttributes.hpp
+++ b/include/LIEF/PE/signature/AuthenticatedAttributes.hpp
@@ -49,6 +49,9 @@ class LIEF_API AuthenticatedAttributes : public Object {
   //! @brief Return an URL to website with more information about the signer
   const std::string& more_info(void) const;
 
+  //! @brief Return the raw bytes associated with the AuthenticatedAttributes
+  const std::vector<uint8_t>& raw(void) const;
+
   virtual void accept(Visitor& visitor) const override;
 
   virtual ~AuthenticatedAttributes(void);
@@ -62,6 +65,7 @@ class LIEF_API AuthenticatedAttributes : public Object {
 
   std::u16string program_name_;
   std::string    more_info_;
+  std::vector<uint8_t> raw_;
 
 };
 

--- a/include/LIEF/PE/signature/ContentInfo.hpp
+++ b/include/LIEF/PE/signature/ContentInfo.hpp
@@ -50,6 +50,9 @@ class LIEF_API ContentInfo : public Object {
   //! @brief The digest
   const std::vector<uint8_t>& digest(void) const;
 
+  //! @brief Return the raw bytes associated with the ContentInfo
+  const std::vector<uint8_t>& raw(void) const;
+
   virtual void accept(Visitor& visitor) const override;
 
   virtual ~ContentInfo(void);
@@ -64,7 +67,7 @@ class LIEF_API ContentInfo : public Object {
 
   oid_t digest_algorithm_; // algorithm used to hash the file (should match Signature::digest_algorithms_)
   std::vector<uint8_t> digest_; //hash value
-
+  std::vector<uint8_t> raw_; // raw bytes
 
 };
 

--- a/src/PE/signature/AuthenticatedAttributes.cpp
+++ b/src/PE/signature/AuthenticatedAttributes.cpp
@@ -44,6 +44,10 @@ const std::string& AuthenticatedAttributes::more_info(void) const {
   return this->more_info_;
 }
 
+const std::vector<uint8_t>& AuthenticatedAttributes::raw(void) const {
+  return this->raw_;
+}
+
 void AuthenticatedAttributes::accept(Visitor& visitor) const {
   visitor.visit(*this);
 }

--- a/src/PE/signature/ContentInfo.cpp
+++ b/src/PE/signature/ContentInfo.cpp
@@ -44,6 +44,9 @@ const std::vector<uint8_t>& ContentInfo::digest(void) const {
   return this->digest_;
 }
 
+const std::vector<uint8_t>& ContentInfo::raw(void) const {
+  return this->raw_;
+}
 
 void ContentInfo::accept(Visitor& visitor) const {
   visitor.visit(*this);


### PR DESCRIPTION
Part of Authenticode verification consists of:
 - Comparing the computed Authenticode hash to the digest
   stored in the ContentInfo section
 - Comparing hash(ContentInfo) to the digest stored in the
   AuthenticatedAttributes section
 - Verifying signed(hash(AuthenticatedAttributes)) using a
   certificate identified by the issuer and serial number
   specified in the SignerInfo section

This commit makes it so that the raw bytes needed to
calculate hash(ContentInfo) and hash(AuthenticatedAttributes)
are available for use.

We could compute the hashes in LIEF and just make those
available instead, or we could perform the validation
outright and pass this info back through a boolean value
or something... Just exposing the raw bytes and letting
the application perform this check (if needed) is simpler,
though (especially for me, since I'm not familiar with a
lot of the C++ features used in this code base).

Also:

Some executables have MoreInfo but not a ProgramName (and the documentation
lists both as OPTIONAL), so handle this case correctly.

Example - 01416b1730218454c99b13592650cb170402b86742b4bab971565903b841829b:

```
SEQUENCE (2 elem)
  OBJECT IDENTIFIER 1.3.6.1.4.1.311.2.1.12 spcSpOpusInfo (Microsoft code signing)
  SET (1 elem)
    SEQUENCE (1 elem)
      [1] (1 elem)
        [0] http://www.mozilla.com
```

Also:

When parsing the issuer serial number, call mbedtls_x509_get_serial instead of
parsing it as an integer directly with mbedtls_asn1_get_mpi. These two functions
differ in how they treat serial numbers prepended with '00' to prevent them from
being negative (the former preserves the '00', and the latter discards it). The
embedded certs are parsed via a call to mbedtls_x509_crt_parse_der, which uses
mbedtls_x509_get_serial behind the scenes, so there was an inconsistency between
lief_obj.signature.signer_info.issuer[1] and
lief_obj.signature.certificates[x].serial_number.

Example - 8bf57d97dd917c4f823659266caaa33e7398406daf11ba8318e3f7414ee3fb24

Before:
```
Certificates
============

...

Version:                      3
Serial Number:                00:bc:2c:93:d5:dc:d4:e6:54:32:a4:cc:ee:34:4a:f5:d3
Signature Algorithm:          SHA1_WITH_RSA_ENCRYPTION
Valid from:                   2007-2-21 0:0:0
Valid to:                     2009-2-20 23:59:59
Issuer:                       C=US, ST=UT, L=Salt Lake City, O=The USERTRUST Network, OU=http://www.usertrust.com, CN=UTN-USERFirst-Object
Subject:                      C=GB, postalCode=HP6 5RW, ST=Buckinghamshire, L=Amersham,, ??=Hyde Heath,, ??=Weedon Hill,, ??=Barsham,, O=Data Perceptions, CN=Data Perceptions

Signer Info
===========
Version:                      1
Serial Number:                bc:2c:93:d5:dc:d4:e6:54:32:a4:cc:ee:34:4a:f5:d3
Issuer DN:                    C=US, ST=UT, L=Salt Lake City, O=The USERTRUST Network, OU=http://www.usertrust.com, CN=UTN-USERFirst-Object
Digest Algorithm:             SHA1
Signature algorithm:          RSA_ENCRYPTION
Content type:                 1.3.6.1.4.1.311.2.1.4
Program name:                 N/A
URL :                         N/A
```

After:

```
Certificates
============

...

Version:                      3
Serial Number:                00:bc:2c:93:d5:dc:d4:e6:54:32:a4:cc:ee:34:4a:f5:d3
Signature Algorithm:          SHA1_WITH_RSA_ENCRYPTION
Valid from:                   2007-2-21 0:0:0
Valid to:                     2009-2-20 23:59:59
Issuer:                       C=US, ST=UT, L=Salt Lake City, O=The USERTRUST Network, OU=http://www.usertrust.com, CN=UTN-USERFirst-Object
Subject:                      C=GB, postalCode=HP6 5RW, ST=Buckinghamshire, L=Amersham,, ??=Hyde Heath,, ??=Weedon Hill,, ??=Barsham,, O=Data Perceptions, CN=Data Perceptions

Signer Info
===========
Version:                      1
Serial Number:                00:bc:2c:93:d5:dc:d4:e6:54:32:a4:cc:ee:34:4a:f5:d3
Issuer DN:                    C=US, ST=UT, L=Salt Lake City, O=The USERTRUST Network, OU=http://www.usertrust.com, CN=UTN-USERFirst-Object
Digest Algorithm:             SHA1
Signature algorithm:          RSA_ENCRYPTION
Content type:                 1.3.6.1.4.1.311.2.1.4
Program name:                 N/A
URL :                         N/A
```

Also:

Handle CHOICEs for the SpcLink and SpcString blocks within SpcSpOpusInfo.  Handling some of them would require bigger changes, so for now just handle the easy ones and safely skip the others.

Example - 1b2488b1d4ba2ed1e96531618a324e226201f0da026a66d6916f67668ae809e7

```
SEQUENCE (2 elem)
  OBJECT IDENTIFIER 1.3.6.1.4.1.311.2.1.12 spcSpOpusInfo (Microsoft code signing)
  SET (1 elem)
    SEQUENCE (2 elem)
      [0] (1 elem)
        [1] Zoom Launcher
      [1] (1 elem)
        [0] http://zoom.us
```

Also:

Allow processing to continue when mbed TLS fails to parse a stored cert, and set the flags to enable MD2 / MD4 sigs to be parsed (the former is used fairly commonly in older signed exes).

Example - 1cb16f94cebdcad7dd05c8537375a6ff6379fcdb08528fc83889f26efaa84e2a

Also:

Some older signed executables use certs with the SpcSpAgencyInfo Critical Extension, which mbed TLS doesn't support, so set MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION to have it
skip this extension.

Example - 781ca31416ec708a587851dafd90c661b86f244ab8b8475c4185e958e54ff838

Also:

For a few signatures where the issuer name contained non-utf8 characters, accessing the issuer name field in Python would raise a UnicodeDecodeError exception. Now this field is handled the same way the names in the individual certs are (I'm not sure if they get represented 100% correctly, but at least they are consistent, which is good enough for me).

Example - 048f91b9302c88380fc66adac1e314d82733089ef3a31eadca5f0cb4169b195f