### PR TITLE
Remove .git directory from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 build
-.git


### PR DESCRIPTION
As `setup.py` uses `git` to determine the version number, we need to copy the contents of `.git` into the image. This currently causes the `0.0.0` version to be used as the `get_version` function [fails to correctly determine](https://travis-ci.org/lief-project/LIEF/jobs/589846000#L596) the version.