### PR TITLE
Use ifstream::read method to read file data instead of std::copy.

### DIFF
--- a/src/BinaryStream/VectorStream.cpp
+++ b/src/BinaryStream/VectorStream.cpp
@@ -38,11 +38,7 @@ VectorStream::VectorStream(const std::string& filename) {
 
     // reserve capacity
     this->binary_.resize(this->size() + 30, 0);
-    std::copy(
-      std::istreambuf_iterator<char>(binary),
-      std::istreambuf_iterator<char>(),
-      std::begin(this->binary_)
-    );
+    binary.read(reinterpret_cast<char*>(binary_.data()), this->size_);
     binary.close();
   } else {
     throw LIEF::bad_file("Unable to open " + filename);


### PR DESCRIPTION
Improves the time to load and parse a large executable (~100MB) on my machine from ~1000ms to ~400ms.