### PR TITLE
Binaries generated with --emit-relocs have dynamic and section relocations

### DIFF
--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -430,25 +430,24 @@ void Parser::parse_binary(void) {
   }
 
   // Try to parse using sections
-  if (this->binary_->relocations_.size() == 0) {
-    for (const Section& section : this->binary_->sections()) {
 
-      try {
-        if (section.type() == ELF_SECTION_TYPES::SHT_REL) {
+  for (const Section& section : this->binary_->sections()) {
 
-          this->parse_section_relocations<ELF_T, typename ELF_T::Elf_Rel>(section);
-        }
-        else if (section.type() == ELF_SECTION_TYPES::SHT_RELA) {
-          this->parse_section_relocations<ELF_T, typename ELF_T::Elf_Rela>(section);
-        }
-
-      } catch (const exception& e) {
-        LOG(WARNING) << "Unable to parse relocations from section '"
-                     << section.name() << "'"
-                     << " (" << e.what() << ")";
+    try {
+      if (section.type() == ELF_SECTION_TYPES::SHT_REL) {
+        this->parse_section_relocations<ELF_T, typename ELF_T::Elf_Rel>(section);
       }
+      else if (section.type() == ELF_SECTION_TYPES::SHT_RELA) {
+        this->parse_section_relocations<ELF_T, typename ELF_T::Elf_Rela>(section);
+      }
+
+    } catch (const exception& e) {
+      LOG(WARNING) << "Unable to parse relocations from section '"
+                   << section.name() << "'"
+                   << " (" << e.what() << ")";
     }
   }
+
 
   this->link_symbol_version();
   this->parse_overlay();


### PR DESCRIPTION
An ELF binary generated with the linker option `--emit-relocs` (https://sourceware.org/binutils/docs/ld/Options.html) will have some dynamic relocations (in `.rela.dyn`) and many more "section" relocations
in e.g. `.rela.text`.

Checking that we do not have any relocation as a condition to parse section relocations makes us miss all those additional relocations. This pull request just removes this check.