### PR TITLE
parse section relocations but do not parse dynamic relocations twice.

### DIFF
--- a/tests/elf/test_parser.py
+++ b/tests/elf/test_parser.py
@@ -220,7 +220,28 @@ class TestTiny(TestCase):
         self.assertEqual(segment.virtual_size, 0x5a)
         self.assertEqual(int(segment.flags), lief.ELF.SEGMENT_FLAGS.R | lief.ELF.SEGMENT_FLAGS.X)
 
+class TestAllRelocs(TestCase):
+    """
+    Test binary generated with all relocation sections.
+    """
 
+    def setUp(self):
+        self.logger = logging.getLogger(__name__)
+        self.bin_with_relocs = lief.parse(get_sample('ELF/ELF64_x86-64_hello-with-relocs.bin'))
+
+    def test_relocations(self):
+        relocations = self.bin_with_relocs.relocations
+        i=0
+        for r in relocations:
+            self.logger.warn(str(i)+str(r))
+            i+=1
+        self.assertEqual(len(relocations), 37)
+        # check relocation from .rela.text
+        self.assertEqual(relocations[12].symbol.name,"main")
+        self.assertEqual(relocations[12].address,0x1064)
+        # check relocation from .rela.eh_frame
+        self.assertTrue(relocations[30].has_section)
+        self.assertEqual(relocations[30].address,0x2068)
 
 if __name__ == '__main__':
 

--- a/tests/elf/test_parser.py
+++ b/tests/elf/test_parser.py
@@ -231,10 +231,6 @@ class TestAllRelocs(TestCase):
 
     def test_relocations(self):
         relocations = self.bin_with_relocs.relocations
-        i=0
-        for r in relocations:
-            self.logger.warn(str(i)+str(r))
-            i+=1
         self.assertEqual(len(relocations), 37)
         # check relocation from .rela.text
         self.assertEqual(relocations[12].symbol.name,"main")


### PR DESCRIPTION
An ELF binary generated with the linker option --emit-relocs (https://sourceware.org/binutils/docs/ld/Options.html) will have some dynamic relocations (in .rela.dyn) and many more "section" relocations in e.g. .rela.text.

Those additional relocation sections are only there for debugging purposes and are not allocated.
This change always parses non-allocated relocation sections. For allocated sections, it only parses them if at the beginning we do not have any relocations (mimicking the old behavior). This is to take into account cases like `test_parser.py TestCorrupted`.