### PR TITLE
fix resource parsing bug

### DIFF
--- a/src/PE/ResourcesManager.cpp
+++ b/src/PE/ResourcesManager.cpp
@@ -1107,7 +1107,7 @@ std::vector<ResourceDialog> ResourcesManager::dialogs(void) const {
         // =====
         for (size_t i = 0; i < header->nbof_items; ++i) {
           stream.align(sizeof(uint32_t));
-          VLOG(VDEBUG) << "item[" << std::dec << i << "] offset: 0x" << std::hex << stream.pos();
+          VLOG(VDEBUG) << "item[" << std::dec << i << "] offset: " << std::hex << stream.pos();
           ResourceDialogItem dialog_item;
 
           if (new_dialog.is_extended()) {
@@ -1123,19 +1123,20 @@ std::vector<ResourceDialog> ResourcesManager::dialogs(void) const {
           // window class
           // ------------
           stream.align(sizeof(uint32_t));
-          const uint16_t window_class_hint = stream.read<uint16_t>();
+          const uint16_t window_class_hint = stream.peek<uint16_t>();
 
           if (window_class_hint == 0xFFFF) {
+            stream.increment_pos(sizeof(uint16_t));
             const uint16_t windows_class_ordinal = stream.read<uint16_t>();
             VLOG(VDEBUG) << "Windows class uses ordinal number " << std::dec <<  windows_class_ordinal;
           } else {
             VLOG(VDEBUG) << "Windows class uses unicode string";
             std::u16string window_class_name = stream.read_u16string();
+            VLOG(VDEBUG) << "[DEBUG] " << u16tou8(window_class_name);
           }
 
           // Title
           // -----
-          stream.align(sizeof(uint32_t));
           const uint16_t title_hint = stream.peek<uint16_t>();
 
           if (title_hint == 0xFFFF) {


### PR DESCRIPTION
In the current implementation of LIEF, `ResourcesManager::dialogs` does not parse the `DLGITEMTEMPLATEEX` structure correctly. This pull request fixes this issue.

https://github.com/lief-project/LIEF/blob/1014ba0ad1a3253e1a08aa0e5f30d3533638013f/src/PE/ResourcesManager.cpp#L1136-L1140

`stream.align(sizeof(uint32_t));` is not nessecary. `windowsClass` could be a null-terminated Unicode string, so the start address of `title` is not always 32 bytes aligned.

This causes the parsing error for some PE files. For example, [NVIDIA Control Panel Application, 8.1.940.0](https://www.virustotal.com/gui/file/ea8b7d9191ea9b6d0d1991f61240285582e3fb1f7d5c08ccf53eb7e3260eae08/detection), the following script

```python
import lief
lief.to_json(lief.parse("nvcplui.exe"))
```

throws `'_pylief.read_out_of_bound'>, read_out_of_bound("Try to read 0x2 bytes from 0x45a (45c) which is bigger than the binary's size",)` exception. This pull request fixes the above parsing error.

It also includes other minor fixes regarding the parsing of `DLGITEMTEMPLATEEX` structure.

Could you merge this pull request?
