### PR TITLE
This PR introduces several performance optimizations for the binary write/build process

### DIFF
--- a/include/LIEF/ELF/Builder.hpp
+++ b/include/LIEF/ELF/Builder.hpp
@@ -1,5 +1,6 @@
 /* Copyright 2017 R. Thomas
  * Copyright 2017 Quarkslab
+ * Copyright 2020, NVIDIA CORPORATION. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +21,7 @@
 #include <memory>
 #include <algorithm>
 #include <string>
+#include <unordered_map>
 
 #include "LIEF/visibility.h"
 #include "LIEF/iostream.hpp"
@@ -96,7 +98,8 @@ class LIEF_API Builder {
     void build_symbol_definition(void);
 
     template<typename T, typename HANDLER>
-    std::vector<std::string> optimize(const HANDLER& e);
+    std::vector<std::string> optimize(const HANDLER& e,
+                                      std::unordered_map<std::string, size_t> *of_map_p=nullptr);
 
     template<typename ELF_T>
     void build_symbol_version(void);

--- a/include/LIEF/ELF/Segment.hpp
+++ b/include/LIEF/ELF/Segment.hpp
@@ -81,6 +81,9 @@ class LIEF_API Segment : public Object {
     void alignment(uint64_t alignment);
     void content(const std::vector<uint8_t>& content);
     void content(std::vector<uint8_t>&& content);
+    template<typename T> T get_content_value(size_t offset) const;
+    template<typename T> void set_content_value(size_t offset, T value);
+    size_t get_content_size() const;
 
     it_sections       sections(void);
     it_const_sections sections(void) const;

--- a/include/LIEF/iterators.hpp
+++ b/include/LIEF/iterators.hpp
@@ -1,5 +1,6 @@
 /* Copyright 2017 R. Thomas
  * Copyright 2017 Quarkslab
+ * Copyright 2020, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -367,7 +368,8 @@ class filter_iterator : public std::iterator<
   }
 
   filter_iterator end(void) const {
-    filter_iterator it_end{this->container_, this->filters_};
+    // we don't need filter for the end iterator
+    filter_iterator it_end{this->container_};
 
     it_end.it_       =  it_end.container_.end();
     it_end.distance_ = it_end.container_.size();
@@ -432,7 +434,8 @@ class filter_iterator : public std::iterator<
     filter_iterator it = this->begin();
     size_t size = 0;
 
-    while (it++ != std::end(it)) size++;
+    auto end_iter = std::end(it);
+    for (; it != end_iter; ++it) ++size;
     this->size_c_ = size;
     return this->size_c_;
   }

--- a/src/ELF/Binary.tcc
+++ b/src/ELF/Binary.tcc
@@ -234,8 +234,8 @@ void Binary::patch_addend(Relocation& relocation, uint64_t from, uint64_t shift)
   VLOG(VDEBUG) << "Patch addend relocation at address: 0x" << std::hex << address;
   Segment& segment = segment_from_virtual_address(address);
   const uint64_t relative_offset = this->virtual_address_to_offset(address) - segment.file_offset();
-  std::vector<uint8_t> segment_content = segment.content();
-  const size_t segment_size = segment_content.size();
+
+  const size_t segment_size = segment.get_content_size();
 
   if (segment_size == 0) {
     LOG(WARNING) << "Segment is empty nothing to do";
@@ -247,13 +247,13 @@ void Binary::patch_addend(Relocation& relocation, uint64_t from, uint64_t shift)
     return;
   }
 
-  T* value = reinterpret_cast<T*>(segment_content.data() + relative_offset);
+  T value = segment.get_content_value<T>(relative_offset);
 
-  if (value != nullptr and *value >= from) {
-    *value += shift;
+  if (value >= from) {
+    value += shift;
   }
 
-  segment.content(segment_content);
+  segment.set_content_value(relative_offset, value);
 }
 
 


### PR DESCRIPTION
- it changes the way how the number of symbols is reduced and how offsets to names are calculated.
  Instead of n^2 algorithms, it introduces nlog(n) algorithm.
  When the symbols optimization step is performed map<symbol_name, offset_to_name>
  is created so it saves another n^2 pass
- a couple of performance improvements to filter_iterator - from pre to post incrementation
  to save an unneeded copy, memoization of end iterator as the compiler cannot do it on its own
  and recreates it every loop iteration, simplified construction of the end iterator
  on the test binary that has a couple of hundreds of MB, it reduces the execution time of
  elf_add_section example form 20 minutes to a couple of seconds
- adds an ability to modify single value inplace in the sectiton to save coying it just to do that
- the reason behind this patch is to use LIEF as a patchelf replacement so the performance
  is one of the factors

Internal tracker http://nvbugs/2976059

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>