### PR TITLE
Fix to parse PE files that have empty fixed_file_version entry

### DIFF
--- a/src/PE/ResourcesManager.cpp
+++ b/src/PE/ResourcesManager.cpp
@@ -470,6 +470,10 @@ ResourceVersion ResourcesManager::version(void) const {
   }
   stream.align(sizeof(uint32_t));
 
+  if (!stream.can_read<uint16_t>()) {
+    VLOG(VDEBUG) << "There is no entry";
+    return version;
+  }
 
   { // First entry
     VLOG(VDEBUG) << "Parsing first entry";


### PR DESCRIPTION
The following samples have version info resources, but LIEF (master b99e791) cannot show these version info resources while ResourcesManager is parsing resources tree structure. 
  - https://www.virustotal.com/gui/file/6ec56de53ef1ea66c81b3e48f9a9b3cf3dc8e3ebda1ec08bf95cc21228a4c7b3/details
  - https://www.virustotal.com/gui/file/9e10a1abbff4d421eaee20040fb2a9270c4efb6d75ee6cd728b09bac1042bfa6
  - https://www.virustotal.com/gui/file/69b07aae04af6ca57d6066fdcbfeeb4c4849bfd2cd65b01c1e576f45b1c24d79

This pull request fixes this issue.

## Details of this issue
Run the following python script

```
import lief
lief.Logger.set_level(lief.LOGGING_LEVEL.DEBUG)
lief.to_json(lief.parse("~/bin/6ec56de53ef1ea66c81b3e48f9a9b3cf3dc8e3ebda1ec08bf95cc21228a4c7b3"))
# lief.to_json(lief.parse("~/bin/9e10a1abbff4d421eaee20040fb2a9270c4efb6d75ee6cd728b09bac1042bfa6"))
# lief.to_json(lief.parse("~/bin/69b07aae04af6ca57d6066fdcbfeeb4c4849bfd2cd65b01c1e576f45b1c24d79"))
```

, then get the following error.

```
... 
[+] Parsing resources
Resources RVA: 0xd000
Resources Offset: 0xd000
[+] Parsing symbols
Parsing Overlay
Overlay offset: 0x3a000
Lenght of the struct: 0x5c
Size of the 'FixedFileInfo' struct34
Parsing first entry
Can't read 2 bytes at 0x5c (0x2 bytes out of bound)
Traceback (most recent call last):
  File "crash_test.py", line 8, in <module>
    lief.to_json(lief.parse("~/bin/48fdc29e7f47e5d38c88a89667ed85740628bf4f4ce95045019f7ebfeb4bbb5c"))
lief.read_out_of_bound: Try to read 0x2 bytes from 0x5c (5e) which is bigger than the binary's size   
```