### PR TITLE
fix to avoid SIGSEGV while parsing the file that has an empty group icon

### DIFF
--- a/src/PE/ResourcesManager.cpp
+++ b/src/PE/ResourcesManager.cpp
@@ -761,7 +761,16 @@ std::vector<ResourceIcon> ResourcesManager::icons(void) const {
   for (const ResourceNode& grp_icon_lvl2 : it_grp_icon->childs()) {
     for (const ResourceNode& grp_icon_lvl3 : grp_icon_lvl2.childs()) {
       const ResourceData* icon_group_node = dynamic_cast<const ResourceData*>(&grp_icon_lvl3);
+      if (!icon_group_node) {
+        LOG(ERROR) << "Group icon node is null";
+        continue;
+      }
+
       const std::vector<uint8_t>& icon_group_content = icon_group_node->content();
+      if (icon_group_content.empty()) {
+        LOG(ERROR) << "Group icon is empty";
+        continue;
+      }
 
       const pe_resource_icon_dir* group_icon_header = reinterpret_cast<const pe_resource_icon_dir*>(icon_group_content.data());
 


### PR DESCRIPTION
LIEF exits with SIGSEGV while parsing the following files:
- [`257a165e834c68645c4324f90e16f5e92c11026ab22734da402b972986d31ac8`](https://www.virustotal.com/gui/file/257a165e834c68645c4324f90e16f5e92c11026ab22734da402b972986d31ac8/details)
- [`145184a7c38dfd26579e8e36064b10508d35ece59b0ea9111086bc8dd5342bb1`](https://www.virustotal.com/gui/file/145184a7c38dfd26579e8e36064b10508d35ece59b0ea9111086bc8dd5342bb1/detection)

This issue is caused by the null pointer access of `icon_group_node` and `icon_group_content`. This pull request fixes this issue.

At first, I was wondering LIEF does not parse the resources in these files correctly. However, for `257a165e834c68645c4324f90e16f5e92c11026ab22734da402b972986d31ac8` rabin2 show the same result

```
$ rabin2 -U 257a165e834c68645c4324f90e16f5e92c11026ab22734da402b972986d31ac8
...
Resource 17
  name: 1
  timestamp: Tue Jan  1 00:00:00 1980
  vaddr: 0x004a47e0
  size: 0 <-------------- empty!
  type: GROUP_ICON
  language: LANG_NEUTRAL

```

, and the information in the VirusTotal details tab shows the same result.

![emtpy_resource](https://user-images.githubusercontent.com/5129526/82905922-72088980-9f9f-11ea-8569-565c087cd173.png)