### PR TITLE
fix to parse the files that have empty dialogs and langs

### DIFF
--- a/src/PE/ResourcesManager.cpp
+++ b/src/PE/ResourcesManager.cpp
@@ -997,10 +997,18 @@ std::vector<ResourceDialog> ResourcesManager::dialogs(void) const {
   for (size_t i = 0; i < nodes.size(); ++i) {
 
     const ResourceDirectory* dialog = dynamic_cast<const ResourceDirectory*>(&nodes[i]);
+    if (!dialog) {
+      LOG(WARNING) << "Dialog is empty. Skipping";
+      continue;
+    }
     it_const_childs langs = dialog->childs();
 
     for (size_t j = 0; j < langs.size(); ++j) {
       const ResourceData* data_node = dynamic_cast<const ResourceData*>(&langs[j]);
+      if (!data_node) {
+        LOG(WARNING) << "Dialog is empty. Skipping";
+        continue;
+      }
       const std::vector<uint8_t>& content = data_node->content();
       VectorStream stream{content};
       stream.setpos(0);


### PR DESCRIPTION
LIEF exists with SIGSEGV while parsing the following files (similar to #419). This pull request fixes this issue.
- [`f7115277cfd63e54800fa1e50bf115280466e81d3f98d9e067777808f9c02b57`](https://www.virustotal.com/gui/file/f7115277cfd63e54800fa1e50bf115280466e81d3f98d9e067777808f9c02b57/details)
- [`a35bcdf9476ffbf938472d8d4485fa5ebe8747dd0b16fb991f4f52b0eca6d72b`](https://www.virustotal.com/gui/file/a35bcdf9476ffbf938472d8d4485fa5ebe8747dd0b16fb991f4f52b0eca6d72b/details)
