### PR TITLE
add stream buffer size limit

### DIFF
--- a/src/PE/Parser.cpp
+++ b/src/PE/Parser.cpp
@@ -485,16 +485,16 @@ void Parser::parse_symbols(void) {
     const pe_symbol& raw_symbol = this->stream_->peek<pe_symbol>(current_offset);
     Symbol symbol{&raw_symbol};
 
-    std::string name;
+    const auto stream_max_size = this->stream_->size();
     if ((raw_symbol.Name.Name.Zeroes & 0xffff) != 0) {
       std::string shortname{raw_symbol.Name.ShortName, sizeof(raw_symbol.Name.ShortName)};
-      name = shortname.c_str();
+      symbol.name_ = shortname.c_str();
     } else {
       uint64_t offset_name =
         this->binary_->header().pointerto_symbol_table() +
         this->binary_->header().numberof_symbols() * STRUCT_SIZES::Symbol16Size +
         raw_symbol.Name.Name.Offset;
-      symbol.name_ = this->stream_->peek_string_at(offset_name);
+      symbol.name_ = this->stream_->peek_string_at(offset_name, stream_max_size - offset_name);
     }
 
     if (symbol.section_number() > 0 and


### PR DESCRIPTION
The following files have large symbols that are not null-terminated.
- [`ed2f4c0b137912ffab9202bd551450c6c36e21b0c0fc7e1bd97096a6db105387`](https://www.virustotal.com/gui/file/ed2f4c0b137912ffab9202bd551450c6c36e21b0c0fc7e1bd97096a6db105387/details)
- [`79edfb80245080efe9a2e3ef9a22184a41654e165eb734b363a31e79eda3e586`](https://www.virustotal.com/gui/file/79edfb80245080efe9a2e3ef9a22184a41654e165eb734b363a31e79eda3e586/details)
- [`2975d4940a61e6b460013d56bdceea7a0b6f7d3254a405f7c796c465024e6043`](https://www.virustotal.com/gui/file/2975d4940a61e6b460013d56bdceea7a0b6f7d3254a405f7c796c465024e6043/detection)

LIEF tries to read these contents at 
https://github.com/lief-project/LIEF/blob/ee45d512d8c2d6ef01c4daa91ebe359565f6b17f/src/PE/Parser.cpp#L496-L498. However, since these symbol strings are not null-terminated, `read_out_of_bound` exception is thrown while reading this string.

This pull request fixes this issue by adding the upper bound of reading size.
