### PR TITLE
add some missing records in json dump

### DIFF
--- a/src/PE/json.cpp
+++ b/src/PE/json.cpp
@@ -148,6 +148,16 @@ void JsonVisitor::visit(const Binary& binary) {
     this->node_["signature"] = visitor.get();
   }
 
+  std::vector<json> symbols;
+  for (const Symbol& symbol : binary.symbols()) {
+    JsonVisitor visitor;
+    visitor(symbol);
+    symbols.emplace_back(visitor.get());
+  }
+  if (!symbols.empty()) {
+    this->node_["symbols"] = symbols;
+  }
+
   // Load Configuration
   if (binary.has_configuration()) {
     JsonVisitor visitor;
@@ -272,6 +282,7 @@ void JsonVisitor::visit(const Section& section) {
   this->node_["pointerto_line_numbers"] = section.pointerto_line_numbers();
   this->node_["numberof_relocations"]   = section.numberof_relocations();
   this->node_["numberof_line_numbers"]  = section.numberof_line_numbers();
+  this->node_["entropy"]                = section.entropy();
   this->node_["characteristics"]        = characteristics;
   this->node_["types"]                  = types;
 }


### PR DESCRIPTION
This is a minor fix. `lief.to_json` does not include some records, such as symbols and entropy value. This pull request adds these records.