### PR TITLE
improve #400

### DIFF
--- a/api/python/Abstract/objects/pyParser.cpp
+++ b/api/python/Abstract/objects/pyParser.cpp
@@ -18,6 +18,7 @@
 #include "LIEF/Abstract/Parser.hpp"
 
 #include <string>
+#include <stdexcept>
 
 namespace LIEF {
 template<>
@@ -31,9 +32,15 @@ void create<Parser>(py::module& m) {
           std::make_move_iterator(std::end(raw_str))
         };
         std::unique_ptr<Binary> binary;
+        std::exception_ptr ep;
         Py_BEGIN_ALLOW_THREADS
-        binary = Parser::parse(std::move(raw), name);
+        try {
+          binary = Parser::parse(std::move(raw), name);
+        } catch (...) {
+          ep = std::current_exception();
+        }
         Py_END_ALLOW_THREADS
+        if (ep) std::rethrow_exception(ep);
         return binary;
       },
       "Parse the given binary and return a " RST_CLASS_REF(lief.Binary) " object",
@@ -43,9 +50,15 @@ void create<Parser>(py::module& m) {
   m.def("parse",
       [] (const std::string& name) {
         std::unique_ptr<Binary> binary;
+        std::exception_ptr ep;
         Py_BEGIN_ALLOW_THREADS
-        binary = Parser::parse(name);
+        try {
+          binary = Parser::parse(name);
+        } catch (...) {
+          ep = std::current_exception();
+        }
         Py_END_ALLOW_THREADS
+        if (ep) std::rethrow_exception(ep);
         return binary;
       },
       "Parse the given binary and return a " RST_CLASS_REF(lief.Binary) " object",
@@ -55,9 +68,15 @@ void create<Parser>(py::module& m) {
   m.def("parse",
       [](const std::vector<uint8_t>& raw, const std::string& name) {
         std::unique_ptr<Binary> binary;
+        std::exception_ptr ep;
         Py_BEGIN_ALLOW_THREADS
-        binary = Parser::parse(raw, name);
+        try {
+          binary = Parser::parse(raw, name);
+        } catch (...) {
+          ep = std::current_exception();
+        }
         Py_END_ALLOW_THREADS
+        if (ep) std::rethrow_exception(ep);
         return binary;
       },
       "Parse the given binary and return a " RST_CLASS_REF(lief.Binary) " object",
@@ -99,9 +118,15 @@ void create<Parser>(py::module& m) {
         };
 
         std::unique_ptr<Binary> binary;
+        std::exception_ptr ep;
         Py_BEGIN_ALLOW_THREADS
-        binary = Parser::parse(std::move(raw), name);
+        try {
+          binary = Parser::parse(std::move(raw), name);
+        } catch (...) {
+          ep = std::current_exception();
+        }
         Py_END_ALLOW_THREADS
+        if (ep) std::rethrow_exception(ep);
         return binary;
       },
       "io"_a,


### PR DESCRIPTION
While releasing GIL, pybind11 does not handle a C++ exception as a Python exception (I don't know why, but [simple pybind11 sample](https://gist.github.com/kohnakagawa/a5fc1e974e118615031730c7ab8d5b71) reproduces the same problem.). Due to this, if an exception is thrown while parsing a binary (e.g., [this file](https://www.virustotal.com/gui/file/ef0df21a292c5a93aaf40a51a355e1e42343c3f9304ba3f6d978cdf4636f2240/detection)), LIEF exits with SIGSEGV.

This pull request fixes this issue.