### PR TITLE
Fix has_exceptions to check exception table

### DIFF
--- a/src/PE/Binary.cpp
+++ b/src/PE/Binary.cpp
@@ -346,7 +346,7 @@ bool Binary::has_resources(void) const {
 }
 
 bool Binary::has_exceptions(void) const {
-  return this->has(DATA_DIRECTORY::EXPORT_TABLE);
+  return this->has(DATA_DIRECTORY::EXCEPTION_TABLE);
   //return this->has_exceptions_;
 }
 


### PR DESCRIPTION
Change has_exceptions to check the exception table instead of the export table.