### PR TITLE
Fixed section extension shifting

### DIFF
--- a/include/LIEF/ELF/Section.hpp
+++ b/include/LIEF/ELF/Section.hpp
@@ -102,6 +102,7 @@ class LIEF_API Section : public LIEF::Section {
     //! @see offset
     uint64_t file_offset(void) const;
     uint64_t original_size(void) const;
+    uint64_t content_size(void) const;
     uint64_t alignment(void) const;
     uint64_t information(void) const;
     uint64_t entry_size(void) const;
@@ -121,6 +122,7 @@ class LIEF_API Section : public LIEF::Section {
     void information(uint32_t info);
     void alignment(uint64_t alignment);
     void entry_size(uint64_t entry_size);
+    void content_size(uint64_t size);
 
     it_segments       segments(void);
     it_const_segments segments(void) const;
@@ -142,6 +144,7 @@ class LIEF_API Section : public LIEF::Section {
     ELF_SECTION_TYPES     type_;
     uint64_t              flags_;
     uint64_t              original_size_;
+    uint64_t              content_size_;
     uint32_t              link_;
     uint32_t              info_;
     uint64_t              address_align_;

--- a/include/LIEF/logging++.hpp
+++ b/include/LIEF/logging++.hpp
@@ -5,11 +5,12 @@
 #include "easylogging++.h"
 #else
 #include <iostream>
-#define NULL_STREAM if(1){} else std::cerr
+#define NULL_STREAM if(0){} else std::cerr
+#define CERR_STREAM std::cerr
 #define VLOG(...) NULL_STREAM
 #define VLOG_IF(...) NULL_STREAM
 #define CVLOG(...) NULL_STREAM
-#define LOG(...) NULL_STREAM
+#define LOG(...) CERR_STREAM
 #define LOG_IF(...) NULL_STREAM
 #define CHECK(...) NULL_STREAM
 #define CHECK_EQ(...) NULL_STREAM

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -1318,7 +1318,6 @@ Section& Binary::extend(const Section& section, uint64_t size) {
     throw not_found("Unable to find the section " + section.name() + " in the current binary");
   }
 
-
   Section* section_to_extend = *it_section;
 
   uint64_t from_offset  = section_to_extend->offset() + section_to_extend->size();

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -1322,7 +1322,7 @@ Section& Binary::extend(const Section& section, uint64_t size) {
   Section* section_to_extend = *it_section;
 
   uint64_t from_offset  = section_to_extend->offset() + section_to_extend->size();
-  uint64_t from_address = section_to_extend->virtual_address() + size;
+  uint64_t from_address = section_to_extend->virtual_address() + section_to_extend->size();
   uint64_t shift        = size;
 
   this->datahandler_->make_hole(

--- a/src/ELF/Segment.cpp
+++ b/src/ELF/Segment.cpp
@@ -363,9 +363,8 @@ void Segment::content(const std::vector<uint8_t>& content) {
   if (node.size() < content.size()) {
     LOG(WARNING) << "You inserted data in segment '"
                  << to_string(this->type()) << "' It may lead to overaly!" << std::endl;
+    this->physical_size(content.size());
   }
-
-  this->physical_size(node.size());
 
   std::copy(
       std::begin(content),
@@ -396,9 +395,8 @@ void Segment::content(std::vector<uint8_t>&& content) {
   if (node.size() < content.size()) {
     LOG(WARNING) << "You inserted data in segment '"
                  << to_string(this->type()) << "' It may lead to overaly!" << std::endl;
+    this->physical_size(content.size());
   }
-
-  this->physical_size(node.size());
 
   std::move(
       std::begin(content),


### PR DESCRIPTION
section extend is calculated wrong and can result in relocations/symbols being shifted when they shouldn't be. The from_address is where the extension begins, and should be the end of the section.

You can see extend_segment is calculated properly:
https://github.com/lief-project/LIEF/blob/master/src/ELF/Binary.tcc#L572