### PR TITLE
Fix for VS 2015

### DIFF
--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -18,6 +18,7 @@
 #include <numeric>
 #include <sstream>
 #include <map>
+#include <cctype>
 
 #include "LIEF/DWARF/enums.hpp"
 


### PR DESCRIPTION
Fix a compilation error on visual studio 2015:
`
Error C2039: 'isprint': is not a member of 'std'
`