### PR TITLE
Fix module entry point declaration (fixes #404)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,17 +73,15 @@ environment:
       PYTHON64_LIBRARY: "C:\\Python37-x64\\libs\\python37.lib"
 
     # Python 3.8
-    # Skip due to the following error:
-    # Fatal Python error : _PyInterpreterState_Get(): no current thread state
-    # - PYTHON_VERSION:   "3.8"
-    #   PYTHON32_PATH:    "C:\\Python38"
-    #   PYTHON32_INCLUDE: "C:\\Python38\\include"
-    #   PYTHON32_BINARY:  "C:\\Python38\\python.exe"
-    #   PYTHON32_LIBRARY: "C:\\Python38\\libs\\python38.lib"
-    #   PYTHON64_PATH:    "C:\\Python38-x64"
-    #   PYTHON64_INCLUDE: "C:\\Python38-x64\\include"
-    #   PYTHON64_BINARY:  "C:\\Python38-x64\\python.exe"
-    #   PYTHON64_LIBRARY: "C:\\Python38-x64\\libs\\python38.lib"
+    - PYTHON_VERSION:   "3.8"
+      PYTHON32_PATH:    "C:\\Python38"
+      PYTHON32_INCLUDE: "C:\\Python38\\include"
+      PYTHON32_BINARY:  "C:\\Python38\\python.exe"
+      PYTHON32_LIBRARY: "C:\\Python38\\libs\\python38.lib"
+      PYTHON64_PATH:    "C:\\Python38-x64"
+      PYTHON64_INCLUDE: "C:\\Python38-x64\\include"
+      PYTHON64_BINARY:  "C:\\Python38-x64\\python.exe"
+      PYTHON64_LIBRARY: "C:\\Python38-x64\\libs\\python38.lib"
 
 matrix:
   fast_finish: true     # set this flag to immediately finish build once one of the jobs fails.

--- a/api/python/pyLIEF.cpp
+++ b/api/python/pyLIEF.cpp
@@ -50,13 +50,12 @@
 #include "platforms/android/pyAndroid.hpp"
 
 
-py::module LIEF_module("lief", "Python API for LIEF");
-
 PYBIND11_MODULE(lief, LIEF_module) {
 
   LIEF_module.attr("__version__")   = py::str(LIEF_VERSION);
   LIEF_module.attr("__tag__")       = py::str(LIEF_TAG);
   LIEF_module.attr("__is_tagged__") = py::bool_(LIEF_TAGGED);
+  LIEF_module.doc() = "Python API for LIEF";
 
   init_LIEF_Object_class(LIEF_module);
 


### PR DESCRIPTION
Explicit definition of a py::module was only required when using the deprecated PYBIND11_PLUGIN macro; remove this as the second argument of the PYBIND11_MODULE macro will define the variable.
    
Set the docstring as appropriate.
    
Fixes #404.