### PR TITLE
Fix C4146 error when building LIEF with MSVC

### DIFF
--- a/include/LIEF/BinaryStream/BinaryStream.hpp
+++ b/include/LIEF/BinaryStream/BinaryStream.hpp
@@ -36,14 +36,14 @@ class BinaryStream {
 
   int64_t read_dwarf_encoded(uint8_t encoding);
 
-  std::string read_string(size_t maxsize = -1u) const;
-  std::string peek_string(size_t maxsize = -1u) const;
-  std::string peek_string_at(size_t offset, size_t maxsize = -1u) const;
+  std::string read_string(size_t maxsize = ~static_cast<size_t>(0)) const;
+  std::string peek_string(size_t maxsize = ~static_cast<size_t>(0)) const;
+  std::string peek_string_at(size_t offset, size_t maxsize = ~static_cast<size_t>(0)) const;
 
   std::u16string read_u16string(void) const;
   std::u16string peek_u16string(void) const;
 
-  std::string read_mutf8(size_t maxsize = -1ull) const;
+  std::string read_mutf8(size_t maxsize = ~static_cast<size_t>(0)) const;
 
   std::u16string read_u16string(size_t length) const;
   std::u16string peek_u16string(size_t length) const;

--- a/include/LIEF/ELF/enums.inc
+++ b/include/LIEF/ELF/enums.inc
@@ -927,7 +927,7 @@ enum _LIEF_EN(NOTE_TYPES_CORE) {
 
 
 enum _LIEF_EN(NOTE_ABIS) {
-  _LIEF_EI(ELF_NOTE_UNKNOWN)     = -1u,
+  _LIEF_EI(ELF_NOTE_UNKNOWN)     = ~(unsigned int)(0),
   _LIEF_EI(ELF_NOTE_OS_LINUX)    = 0,
   _LIEF_EI(ELF_NOTE_OS_GNU)      = 1,
   _LIEF_EI(ELF_NOTE_OS_SOLARIS2) = 2,


### PR DESCRIPTION
In MSVC, [SDL checks](https://docs.microsoft.com/en-us/cpp/build/reference/sdl-enable-additional-security-checks?view=vs-2019) is enabled by default. Therefore, casting from signed integer to unsigned integer in the following code is prohibited and raises the compilation error (C4146).

```cpp
  // BinaryStream.cpp

  ...

  std::string read_string(size_t maxsize = -1) const;  // <-- error C4146
  std::string peek_string(size_t maxsize = -1) const; // <-- error C4146
  std::string peek_string_at(size_t offset, size_t maxsize = ~size_t(0)) const; // <-- error C4146

  ...

```
This pull-request fixes this minor issue when linking LIEF.lib.
