### PR TITLE
Fix segmentation fault when accessing the raw data of a FatBinary

### DIFF
--- a/src/MachO/Builder.cpp
+++ b/src/MachO/Builder.cpp
@@ -60,7 +60,6 @@ Builder::Builder(FatBinary* fat) :
 
 
 std::vector<uint8_t> Builder::operator()(void) {
-  this->build();
   return this->get_build();
 }
 


### PR DESCRIPTION
Here is how to trigger the segmentation fault:

```cpp
#include <iostream>
#include <LIEF/MachO.hpp>

int main(int argc, const char * argv[])
{
    std::string path = "/usr/bin/yes";
    std::unique_ptr<LIEF::MachO::FatBinary> fat_binary = LIEF::MachO::Parser::parse(path);
    std::vector<uint8_t> raw = fat_binary->raw();
    std::cout << path << " size: " << raw.size() << std::endl;
    fat_binary.reset();
    return 0;
}
```

The `build()` method must not be called when the `Builder` is initilaized with a `FatBinary` because `this->binary_` is null (which causes the segmentation fault when accessing `this->binary_->is64_`). Anyway, calling `get_build()` is enough since `build()`or `build_fat()` is already called in the constructors of the `LIEF::MachO::Builder` class.

Before this commit:

```
./a.out
[1]    37481 segmentation fault  ./a.out
```

Afer this commit:

```
./a.out
/usr/bin/yes size: 30944
```
