### PR TITLE
Changing library artifact suffix take into consideration CRT choice on MSVC based builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,10 +453,23 @@ endif()
 
 find_package(cppcheck)
 
-set_target_properties(
-  LIB_LIEF
-  PROPERTIES OUTPUT_NAME LIEF
-  CLEAN_DIRECT_OUTPUT 1)
+if (MSVC)
+	string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
+	if (build_type STREQUAL "debug")
+		set(CRT_OUTPUT_SUFFIX ${LIEF_USE_CRT_DEBUG})
+	else()
+		set(CRT_OUTPUT_SUFFIX ${LIEF_USE_CRT_RELEASE})
+	endif()
+	set_target_properties(
+		LIB_LIEF
+		PROPERTIES OUTPUT_NAME LIEF${CRT_OUTPUT_SUFFIX}
+		CLEAN_DIRECT_OUTPUT 1)
+else()
+	set_target_properties(
+		LIB_LIEF
+		PROPERTIES OUTPUT_NAME LIEF
+		CLEAN_DIRECT_OUTPUT 1)
+endif()
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
Hi there!

This pull request is referenced to [Issue#478](https://github.com/lief-project/LIEF/issues/478).

Now on ``MSVC`` based builds, the library artifact has as suffix the CRT choice.

Thus, if we run:

> _ cmake -DLIEF_PYTHON_API=off -DCMAKE_BUILD_TYPE=Debug -DLIEF_USE_CRT_DEBUG=MDd

It will give us ´´LIEFMDd.lib´´

> _ cmake -DLIEF_PYTHON_API=off -DCMAKE_BUILD_TYPE=Debug -DLIEF_USE_CRT_DEBUG=MTd

It will give us ´´LIEFMTd.lib´´

> _ cmake -DLIEF_PYTHON_API=off -DCMAKE_BUILD_TYPE=Release -DLIEF_USE_CRT_RELEASE=MD

It will give us ´´LIEFMD.lib´´

> _ cmake -DLIEF_PYTHON_API=off -DCMAKE_BUILD_TYPE=Release -DLIEF_USE_CRT_RELEASE=MT

It will give us ´´LIEFMT.lib´´

Personally, I find that CRT should be composed with CMAKE_BUILD_TYPE and with only one CRT build option, something like:

-  CMAKE_BUILD_TYPE=Release + LIEF_CRT=MD -> LIEFMD.lib 
- CMAKE_BUILD_TYPE=Release + LIEF_CRT=MT -> LIEFMT.lib
- CMAKE_BUILD_TYPE=Debug + LIEF_CRT=MD -> LIEFMDd.lib
- CMAKE_BUILD_TYPE=Debug + LIEF_CRT=MT -> LIEFMTd.lib

It would be much easier to understand and also avoid leading to CRT mismatch errors.

Anyway, my changes take into consideration the current ``LIEF_USE_CRT_RELEASE`` and ``LIEF_USE_CRT_DEBUG``
stuff, but I think that it should be simplified.
