### PR TITLE
add mips to the elf architecture mapping.

### DIFF
--- a/src/ELF/Header.cpp
+++ b/src/ELF/Header.cpp
@@ -39,6 +39,7 @@ static const std::map<ARCH, Header::abstract_architecture_t> arch_elf_to_lief {
   {ARCH::EM_AARCH64,   {ARCH_ARM64, {MODE_64}}},
   {ARCH::EM_386,       {ARCH_X86,   {MODE_32}}},
   {ARCH::EM_IA_64,     {ARCH_INTEL, {MODE_64}}},
+  {ARCH::EM_MIPS,      {ARCH_MIPS,  {MODE_32}}},
   {ARCH::EM_PPC,       {ARCH_PPC,   {MODE_32}}},
   {ARCH::EM_PPC64,     {ARCH_PPC,   {MODE_64}}},
 };


### PR DESCRIPTION
Map the architecture in the elf header for mips with the abstract architecture.