### PR TITLE
Sort dynamic symbols

### DIFF
--- a/include/LIEF/ELF/Builder.hpp
+++ b/include/LIEF/ELF/Builder.hpp
@@ -93,6 +93,8 @@ class LIEF_API Builder {
   template<typename ELF_T>
   void build_symbol_gnuhash(void);
 
+  uint32_t sort_dynamic_symbols(void);
+
   void build_empty_symbol_gnuhash(void);
 
   template<typename ELF_T>

--- a/src/ELF/Builder.cpp
+++ b/src/ELF/Builder.cpp
@@ -111,6 +111,46 @@ void Builder::write(const std::string& filename) const {
 }
 
 
+uint32_t Builder::sort_dynamic_symbols(void) {
+  auto it_begin = std::begin(this->binary_->dynamic_symbols_);
+  auto it_end = std::end(this->binary_->dynamic_symbols_);
+
+  auto it_first_non_local_symbol =
+      std::stable_partition(it_begin, it_end, [](const Symbol* sym) {
+        return sym->binding() == SYMBOL_BINDINGS::STB_LOCAL;
+      });
+  uint32_t first_non_local_symbol_index =
+      std::distance(it_begin, it_first_non_local_symbol);
+  std::string section_name = ".dynsym";
+  if (this->binary_->has_section(section_name)) {
+    Section& section = this->binary_->get_section(section_name);
+    if (section.information() != first_non_local_symbol_index) {
+      // TODO: Erase null entries of dynamic symbol table and symbol version table
+      // if information of .dynsym section is smaller than null entries num.
+      LIEF_WARN("information of {} section changes from {:d} to {:d}",
+                section_name,
+                section.information(),
+                first_non_local_symbol_index);
+      section.information(first_non_local_symbol_index);
+    }
+  }
+
+  auto it_first_exported_symbol = std::stable_partition(
+      it_first_non_local_symbol, it_end, [](const Symbol* sym) {
+        return sym->shndx() ==
+               static_cast<uint16_t>(SYMBOL_SECTION_INDEX::SHN_UNDEF);
+      });
+  uint32_t first_exported_symbol_index =
+      std::distance(it_begin, it_first_exported_symbol);
+  if (this->binary_->gnu_hash().symbol_index() != first_exported_symbol_index) {
+    LIEF_WARN("symndx of .gnu.hash section changes from {:d} to {:d}",
+              this->binary_->gnu_hash().symbol_index(),
+              first_exported_symbol_index);
+  }
+  return first_exported_symbol_index;
+}
+
+
 void Builder::build_empty_symbol_gnuhash(void) {
   LIEF_DEBUG("Build empty GNU Hash");
   auto&& it_gnuhash = std::find_if(

--- a/src/ELF/Builder.tcc
+++ b/src/ELF/Builder.tcc
@@ -892,7 +892,7 @@ void Builder::build_symbol_gnuhash(void) {
   const GnuHash& gnu_hash   = this->binary_->gnu_hash();
 
   const uint32_t nb_buckets = gnu_hash.nb_buckets();
-  const uint32_t symndx     = gnu_hash.symbol_index();
+  const uint32_t symndx     = sort_dynamic_symbols();
   const uint32_t maskwords  = gnu_hash.maskwords();
   const uint32_t shift2     = gnu_hash.shift2();
 


### PR DESCRIPTION
```cpp
// foo.cpp
#include <iostream>
namespace {
int var = 1;

void bar() {
  std::cout << "bar" << std::endl;
}
}  // namespace
void foo() {
}
```

```cpp
// merge.cpp
#include <LIEF/ELF.hpp>
#include <memory>
#include <vector>
int main() {
  std::unique_ptr<LIEF::ELF::Binary> binary_(
      LIEF::ELF::Parser::parse("libfoo.so"));
  std::vector<LIEF::ELF::Symbol> dynamic_symbols{
      binary_->dynamic_symbols().begin(), binary_->dynamic_symbols().end()};
  uint32_t added_symbol_num = 0;
  for (const auto& symbol : dynamic_symbols) {
    binary_->add_dynamic_symbol(symbol);
    added_symbol_num += 1;
  }
  uint64_t entry_size = binary_->get_section(".dynsym").entry_size();
  assert(entry_size == 24);
  binary_->extend(binary_->get_section(".dynsym"),
                  dynamic_symbols.size() * entry_size);
  binary_->write("libfoo-modified.so");
}
```

```makefile
all : clean compile run

clean :
        rm -f libfoo.so merge libfoo-modified.so

compile :
        g++ -std=c++11 foo.cpp -O0 -ggdb -shared -fPIC -o libfoo.so
        g++ -std=c++11 -O0 -ggdb merge.cpp -I/usr/include/LIEF-0.11.0-Linux/include -L/usr/lib/LIEF-0.11.0-Linux/lib -lLIEF -o merge

run :
        ./merge
        chmod u+x libfoo-modified.so
        readelf --dyn-syms libfoo-modified.so
```

Dynamic symbol table of libfoo.so is:

```bash
# readelf --dyn-syms libfoo.so
Symbol table '.dynsym' contains 19 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
     1: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
     2: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _Jv_RegisterClasses
     3: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitC1Ev@GLIBCXX_3.4 (2)
     4: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __cxa_atexit@GLIBC_2.2.5 (3)
     5: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitD1Ev@GLIBCXX_3.4 (2)
     6: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_deregisterTMCloneTab
     7: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZStlsISt11char_traitsIcE@GLIBCXX_3.4 (2)
     8: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_registerTMCloneTable
     9: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND __cxa_finalize@GLIBC_2.2.5 (3)
    10: 0000000000000000     0 OBJECT  GLOBAL DEFAULT  UND _ZSt4cout@GLIBCXX_3.4 (2)
    11: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSolsEPFRSoS_E@GLIBCXX_3.4 (2)
    12: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZSt4endlIcSt11char_trait@GLIBCXX_3.4 (2)
    13: 0000000000201048     0 NOTYPE  GLOBAL DEFAULT   24 _end
    14: 0000000000201044     0 NOTYPE  GLOBAL DEFAULT   23 _edata
    15: 0000000000000932     7 FUNC    GLOBAL DEFAULT   12 _Z3foov
    16: 0000000000201044     0 NOTYPE  GLOBAL DEFAULT   24 __bss_start
    17: 0000000000000788     0 FUNC    GLOBAL DEFAULT    9 _init
    18: 0000000000000998     0 FUNC    GLOBAL DEFAULT   13 _fini
```

Without this change:

```bash
# make
readelf --dyn-syms libfoo-modified.so

Symbol table '.dynsym' contains 38 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
     1: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
     2: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _Jv_RegisterClasses
     3: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitC1Ev@GLIBCXX_3.4 (2)
     4: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __cxa_atexit@GLIBC_2.2.5 (3)
     5: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitD1Ev@GLIBCXX_3.4 (2)
     6: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_deregisterTMCloneTab
     7: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZStlsISt11char_traitsIcE@GLIBCXX_3.4 (2)
     8: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_registerTMCloneTable
     9: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND __cxa_finalize@GLIBC_2.2.5 (3)
    10: 0000000000000000     0 OBJECT  GLOBAL DEFAULT  UND _ZSt4cout@GLIBCXX_3.4 (2)
    11: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSolsEPFRSoS_E@GLIBCXX_3.4 (2)
    12: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZSt4endlIcSt11char_trait@GLIBCXX_3.4 (2)
    13: 0000000000204210     0 NOTYPE  GLOBAL DEFAULT   24 _end
    14: 000000000020420c     0 NOTYPE  GLOBAL DEFAULT   23 _edata
    15: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZStlsISt11char_traitsIcE
    16: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_registerTMCloneTable
    17: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND __cxa_finalize
    18: 0000000000204210     0 NOTYPE  GLOBAL DEFAULT   24 _end
    19: 000000000020420c     0 NOTYPE  GLOBAL DEFAULT   23 _edata
    20: 0000000000003afa     7 FUNC    GLOBAL DEFAULT   12 _Z3foov
    21: 000000000020420c     0 NOTYPE  GLOBAL DEFAULT   24 __bss_start
    22: 0000000000003950     0 FUNC    GLOBAL DEFAULT    9 _init
    23: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __cxa_atexit
    24: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZSt4endlIcSt11char_trait
    25: 0000000000003afa     7 FUNC    GLOBAL DEFAULT   12 _Z3foov
    26: 000000000020420c     0 NOTYPE  GLOBAL DEFAULT   24 __bss_start
    27: 0000000000003950     0 FUNC    GLOBAL DEFAULT    9 _init
    28: 0000000000003b60     0 FUNC    GLOBAL DEFAULT   13 _fini
    29: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
readelf: Warning: local symbol 29 found at index >= .dynsym's sh_info value of 1
    30: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
    31: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _Jv_RegisterClasses
    32: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitC1Ev
    33: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitD1Ev
    34: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_deregisterTMCloneTab
    35: 0000000000000000     0 OBJECT  GLOBAL DEFAULT  UND _ZSt4cout
    36: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSolsEPFRSoS_E
    37: 0000000000003b60     0 FUNC    GLOBAL DEFAULT   13 _fini
```

With this change:

```bash
# make
information of .dynsym section changes from 1 to 2
symndx of .gnu.hash section changes from 13 to 26
symndx of .gnu.hash section changes from 13 to 26
symndx of .gnu.hash section changes from 13 to 26
chmod u+x libfoo-modified.so
readelf --dyn-syms libfoo-modified.so

Symbol table '.dynsym' contains 38 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
     1: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
     2: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
     3: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _Jv_RegisterClasses
     4: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitC1Ev@GLIBCXX_3.4 (2)
     5: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __cxa_atexit@GLIBC_2.2.5 (3)
     6: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitD1Ev@GLIBCXX_3.4 (2)
     7: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_deregisterTMCloneTab
     8: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZStlsISt11char_traitsIcE@GLIBCXX_3.4 (2)
     9: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_registerTMCloneTable
    10: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND __cxa_finalize@GLIBC_2.2.5 (3)
    11: 0000000000000000     0 OBJECT  GLOBAL DEFAULT  UND _ZSt4cout@GLIBCXX_3.4 (2)
    12: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSolsEPFRSoS_E@GLIBCXX_3.4 (2)
    13: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZSt4endlIcSt11char_trait@GLIBCXX_3.4 (2)
    14: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
    15: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _Jv_RegisterClasses
    16: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitC1Ev
    17: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __cxa_atexit
    18: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSt8ios_base4InitD1Ev
    19: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_deregisterTMCloneTab
    20: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZStlsISt11char_traitsIcE
    21: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_registerTMCloneTable
    22: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND __cxa_finalize
    23: 0000000000000000     0 OBJECT  GLOBAL DEFAULT  UND _ZSt4cout
    24: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZNSolsEPFRSoS_E
    25: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND _ZSt4endlIcSt11char_trait
    26: 0000000000204210     0 NOTYPE  GLOBAL DEFAULT   24 _end
    27: 000000000020420c     0 NOTYPE  GLOBAL DEFAULT   23 _edata
    28: 0000000000204210     0 NOTYPE  GLOBAL DEFAULT   24 _end
    29: 000000000020420c     0 NOTYPE  GLOBAL DEFAULT   23 _edata
    30: 0000000000003afa     7 FUNC    GLOBAL DEFAULT   12 _Z3foov
    31: 000000000020420c     0 NOTYPE  GLOBAL DEFAULT   24 __bss_start
    32: 0000000000003950     0 FUNC    GLOBAL DEFAULT    9 _init
    33: 0000000000003afa     7 FUNC    GLOBAL DEFAULT   12 _Z3foov
    34: 000000000020420c     0 NOTYPE  GLOBAL DEFAULT   24 __bss_start
    35: 0000000000003950     0 FUNC    GLOBAL DEFAULT    9 _init
    36: 0000000000003b60     0 FUNC    GLOBAL DEFAULT   13 _fini
    37: 0000000000003b60     0 FUNC    GLOBAL DEFAULT   13 _fini
```