### PR TITLE
Fat MachO: API to "take" a binary from the fat MachO object

### DIFF
--- a/include/LIEF/MachO/FatBinary.hpp
+++ b/include/LIEF/MachO/FatBinary.hpp
@@ -17,6 +17,7 @@
 #define LIEF_MACHO_FAT_BINARY_H_
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "LIEF/types.hpp"
 #include "LIEF/visibility.h"
@@ -61,6 +62,11 @@ class LIEF_API FatBinary {
 
   Binary&       operator[](size_t index);
   const Binary& operator[](size_t index) const;
+
+  //! Extract a @link MachO::Binary@ object. Gives ownership to the caller, and
+  //  remove it from this @link FatBinary object. Warning: this invalidates any
+  //  previously hold iterator!
+  std::unique_ptr<Binary> take(size_t index);
 
   //! Reconstruct the Fat binary object and write it in `filename`
   //! @param filename Path to write the reconstructed binary

--- a/src/MachO/FatBinary.cpp
+++ b/src/MachO/FatBinary.cpp
@@ -91,6 +91,16 @@ const Binary& FatBinary::operator[](size_t index) const {
   return this->at(index);
 }
 
+std::unique_ptr<Binary> FatBinary::take(size_t index) {
+  if (index >= binaries_.size()) {
+    return {};
+  }
+  auto it = binaries_.begin();
+  std::advance(it, index);
+  std::unique_ptr<Binary> ret(*it);
+  binaries_.erase(it);
+  return ret;
+}
 
 void FatBinary::write(const std::string& filename) {
   Builder::write(this, filename);


### PR DESCRIPTION
This gives ownership to the caller, and remove the LIEF::Binary object
from the FatMachO one.