### PR TITLE
Calculate MachO binary available_command_space_

### DIFF
--- a/src/MachO/BinaryParser.tcc
+++ b/src/MachO/BinaryParser.tcc
@@ -120,6 +120,7 @@ void BinaryParser::parse_load_commands(void) {
     LIEF_WARN("Only the first #{:d} will be parsed", nbcmds);
   }
 
+  uint32_t low_fileoff = UINT_MAX;
   for (size_t i = 0; i < nbcmds; ++i) {
     if (not this->stream_->can_read<load_command>(loadcommands_offset)) {
       break;
@@ -158,9 +159,18 @@ void BinaryParser::parse_load_commands(void) {
           for (size_t j = 0; j < segment->numberof_sections(); ++j) {
             const section_t* section_header = &this->stream_->peek<section_t>(local_offset);
             std::unique_ptr<Section> section{new Section{section_header}};
+            if (section->size_ != 0 &&
+              section->type() != MACHO_SECTION_TYPES::S_ZEROFILL &&
+              section->type() != MACHO_SECTION_TYPES::S_THREAD_LOCAL_ZEROFILL &&
+              section->offset_ < low_fileoff) {
+              low_fileoff = section->offset_;
+              }
             section->segment_ = segment;
             segment->sections_.push_back(section.release());
             local_offset += sizeof(section_t);
+          }
+          if (segment->numberof_sections() == 0 && segment->file_offset() != 0 && segment->file_size() != 0 && segment->file_offset() < low_fileoff) {
+            low_fileoff = segment->file_offset();
           }
           break;
         }
@@ -599,6 +609,7 @@ void BinaryParser::parse_load_commands(void) {
     }
     loadcommands_offset += command.cmdsize;
   }
+  this->binary_->available_command_space_ = low_fileoff - loadcommands_offset;
 }
 
 


### PR DESCRIPTION
This value was always set to 0, so space would always be allocated in
the binary for more commands. However it is not necessary to do this as
there will often be space available. This commit adds a simple way to
calculate that during parsing.

This method is taken from Apple's cctools package, specifically the
codesign_allocate tool. See https://github.com/tpoechtrager/cctools-port/blob/466063c7f7486762a5a8f0d98c48dc5ffbe42f74/cctools/misc/codesign_allocate.c#L861