### PR TITLE
MachO: Don't set strings table size based on linkedit size

### DIFF
--- a/src/MachO/Builder.tcc
+++ b/src/MachO/Builder.tcc
@@ -782,15 +782,7 @@ void Builder::build(SymbolCommand* symbol_command) {
   symtab.symoff  = static_cast<uint32_t>(symbol_command->symbol_offset());    // **Usually** After the header
   symtab.nsyms   = static_cast<uint32_t>(symbol_command->numberof_symbols());
   symtab.stroff  = static_cast<uint32_t>(symbol_command->strings_offset());   // **Usually** After nlist table
-
-
-  // TODO: Improve
-  // Update linkedit segment
-  SegmentCommand& linkedit = *this->binary_->get_segment("__LINKEDIT");
-  size_t delta = linkedit.file_offset() + linkedit.file_size();
-  delta = delta - (symbol_command->strings_offset() + symbol_command->strings_size());
-  //std::cout << std::hex << "delta:" << delta << std::endl;
-  symtab.strsize = static_cast<uint32_t>(symbol_command->strings_size() + delta);
+  symtab.strsize = static_cast<uint32_t>(symbol_command->strings_size());
 
   symbol_command->originalData_.clear();
   symbol_command->originalData_.reserve(sizeof(symtab_command));


### PR DESCRIPTION
Given that the strings table size cannot grow, and a smaller strings
table is padded out to the original size, set the strings table size to
symbol_command->strings_size().

Additionally, the previous code would cause the strings table to be
expanded to the rest of the linkedit segment which breaks anything that
may add data to a linkedit segment, or any data that already exists
after the strings table in the linkedit segment. Notably this issue can
be seen when working with MachO binaries that have code signatures as
these are placed at the end of the linkedit segment.