### PR TITLE
WIP: add section to section array even if it is too large.

### DIFF
--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -878,6 +878,9 @@ void Parser::parse_sections(void) {
 
     if (section_end > this->stream_->size() + 200_MB) {
       LIEF_ERR("  Section #{:d} is too large!", i);
+      // Even if the section is too large, add it incomplete
+      // to keep section indexes consistent.
+      this->binary_->sections_.push_back(section.release());
       continue;
     }
 


### PR DESCRIPTION
This is work in progress. I am trying to correct the following situation:

- I have an example binary that has a very large `.bss` section, which triggers the message  `"  Section #{:d} is too large!"`
- However, this has another unfortunate consequence. With the code in master, the loop is continued and that section is not added to the section array. 
- That means that the section indexes in the ELF header and the indexes in `this->binary_->sections` do not coincide anymore.
- As a result, when we get the section names by consulting the `section_name_table_idx` in line 912 of Parser.tcc (right below the changed code), we are actually looking at the wrong section, and that results in a binary where section names are all wrong.

This is one possible solution, but I don't know much about the motivations of having a limits on section sizes, so there might be better ways of handling this. I also don't know for sure if this will break other stuff down the line. 
@romainthomas what do you think?

