### PR TITLE
Fix the number of entries of MIPS_RELOCS

### DIFF
--- a/src/ELF/EnumToString.cpp
+++ b/src/ELF/EnumToString.cpp
@@ -1009,7 +1009,7 @@ const char* to_string(RELOC_POWERPC64 e) {
 }
 
 const char* to_string(RELOC_MIPS e) {
-  CONST_MAP(RELOC_MIPS, const char*, 111) enumStrings {
+  CONST_MAP(RELOC_MIPS, const char*, 112) enumStrings {
     {  RELOC_MIPS::R_MICROMIPS_26_S1,           "MIRCRO_MIPS_26_S1" },
     {  RELOC_MIPS::R_MICROMIPS_CALL16,          "MIRCRO_MIPS_CALL16" },
     {  RELOC_MIPS::R_MICROMIPS_CALL_HI16,       "MIRCRO_MIPS_CALL_HI16" },

--- a/src/ELF/RelocationSizes.hpp
+++ b/src/ELF/RelocationSizes.hpp
@@ -528,7 +528,7 @@ CONST_MAP(RELOC_POWERPC64, uint32_t, 84) relocation_PPC64_sizes {
   { RELOC_POWERPC64::R_PPC64_REL16_HA,            16 },
 };
 
-CONST_MAP(RELOC_MIPS, uint32_t, 111) relocation_MIPS_sizes {
+CONST_MAP(RELOC_MIPS, uint32_t, 112) relocation_MIPS_sizes {
   { RELOC_MIPS::R_MICROMIPS_26_S1,           26 },
   { RELOC_MIPS::R_MICROMIPS_CALL16,          16 },
   { RELOC_MIPS::R_MICROMIPS_CALL_HI16,       16 },


### PR DESCRIPTION
Hi. @romainthomas 

This is a quite small fix.

The number of entries of RELOC_MIPS seems to be wrong. Due to this, master branch HEAD cannot be compiled on my environment. This pull request fixes this issue.