### PR TITLE
Fix IAT Reconstruction

### DIFF
--- a/include/LIEF/PE/enums.hpp.in
+++ b/include/LIEF/PE/enums.hpp.in
@@ -23,7 +23,8 @@ enum class PE_SECTION_TYPES : uint8_t {
   EXPORT     = 7,
   DEBUG      = 8,
   LOAD_CONFIG = 9,
-  UNKNOWN     = 10
+  UNKNOWN     = 10,
+  OLD_IMPORT = 100
 };
 
 enum class PE_TYPE : uint16_t {

--- a/src/PE/Builder.tcc
+++ b/src/PE/Builder.tcc
@@ -184,9 +184,13 @@ void Builder::build_import_table(void) {
         [] (const Section* section) {
           return section != nullptr and section->is_type(PE_SECTION_TYPES::OLD_IMPORT);
         });
-    (*original_import_section)->remove_type(PE_SECTION_TYPES::OLD_IMPORT);
-    auto original_import_offset = (*original_import_section)->pointerto_raw_data();
-    Section& original_import = this->binary_->section_from_offset(original_import_offset);
+    // fallback mechanism
+    const auto is_found = original_import_section != std::end(this->binary_->sections_);
+    if (is_found) {
+      (*original_import_section)->remove_type(PE_SECTION_TYPES::OLD_IMPORT);
+    }
+    auto original_import_offset = is_found ? (*original_import_section)->pointerto_raw_data() : 0;
+    Section& original_import = this->binary_->section_from_offset(is_found ? original_import_offset: offset_imports);
     std::vector<uint8_t> import_content  = original_import.content();
 
     pe_import *import_header = reinterpret_cast<pe_import*>(import_content.data() + offset_imports_in_section);


### PR DESCRIPTION
This will be fix #523

Currently, `this->binary_->section_from_offset(offset_imports)` is used as the original import section. 
However, if the "backward shift" (explained in #523 ) happens, this returns the previous section of the original import section. So I try another way to obtain the original import section.

I introduce `PE_SECTION_TYPES::OLD_IMPORT` type to mark the original import section.
The type will be added to the target section when the `PE_SECTION_TYPES::IMPORT` type will be removed from it.

After adding the new import section, we can find the original import section by  looking to see if the type is `PE_SECTION_TYPES::OLD_IMPORT`. 

If we can not find the original import section, it will fall back to the current implementation, that is, `this->binary_->section_from_offset(offset_imports)` will be used.

macOS and iOS CI jobs currently failed, but I suspect that they are due to the GitHub Actions' issue (https://github.com/actions/virtual-environments/issues/841).
In fact, I see the "(X) This check failed" message and these jobs are unstable...
https://github.com/Catminusminus/LIEF/actions/runs/492792964

Sorry if I my suspicions are wrong. I'll re-run the jobs to find out what's wrong, anyway.