### PR TITLE
Fix build_imports

### DIFF
--- a/include/LIEF/PE/ImportEntry.hpp
+++ b/include/LIEF/PE/ImportEntry.hpp
@@ -66,9 +66,11 @@ class LIEF_API ImportEntry : public Object {
   //! @brief **Original** address of the entry in the Import Address Table
   uint64_t iat_address(void) const;
 
+  bool manually_added(void) const;
 
   void name(const std::string& name);
   void data(uint64_t data);
+  void manually_added(bool manually_added);
 
   virtual void accept(Visitor& visitor) const override;
 
@@ -84,6 +86,8 @@ class LIEF_API ImportEntry : public Object {
   uint64_t    iat_value_;
   uint64_t    rva_;
   PE_TYPE     type_;
+
+  bool manually_added_;
 };
 
 }

--- a/src/PE/Import.cpp
+++ b/src/PE/Import.cpp
@@ -214,12 +214,14 @@ void Import::import_address_table_rva(uint32_t rva) {
 
 ImportEntry& Import::add_entry(const ImportEntry& entry) {
   this->entries_.push_back(entry);
+  this->entries_.back().manually_added(true);
   return this->entries_.back();
 }
 
 
 ImportEntry& Import::add_entry(const std::string& name) {
   this->entries_.emplace_back(name);
+  this->entries_.back().manually_added(true);
   return this->entries_.back();
 }
 

--- a/src/PE/ImportEntry.cpp
+++ b/src/PE/ImportEntry.cpp
@@ -33,7 +33,8 @@ ImportEntry::ImportEntry(void) :
   hint_{0},
   iat_value_{0},
   rva_{0},
-  type_{PE_TYPE::PE32}
+  type_{PE_TYPE::PE32},
+  manually_added_(false)
 {}
 
 ImportEntry::ImportEntry(uint64_t data, const std::string& name) :
@@ -42,7 +43,8 @@ ImportEntry::ImportEntry(uint64_t data, const std::string& name) :
   hint_{0},
   iat_value_{0},
   rva_{0},
-  type_{PE_TYPE::PE32}
+  type_{PE_TYPE::PE32},
+  manually_added_(false)
 {}
 
 
@@ -101,6 +103,10 @@ uint64_t ImportEntry::iat_address(void) const {
   return this->rva_;
 }
 
+bool ImportEntry::manually_added(void) const {
+  return this->manually_added_;
+}
+
 void ImportEntry::name(const std::string& name) {
   this->name_ = name;
 }
@@ -109,6 +115,9 @@ void ImportEntry::data(uint64_t data) {
   this->data_ = data;
 }
 
+void ImportEntry::manually_added(bool manually_added) {
+  this->manually_added_ = manually_added;
+}
 
 void ImportEntry::accept(LIEF::Visitor& visitor) const {
   visitor.visit(*this);
@@ -134,6 +143,7 @@ std::ostream& operator<<(std::ostream& os, const ImportEntry& entry) {
   os << std::setw(20) << entry.data();
   os << std::setw(20) << entry.iat_value();
   os << std::setw(20) << entry.hint();
+  os << std::setw(20) << entry.manually_added();
   return os;
 }
 

--- a/src/PE/hash.cpp
+++ b/src/PE/hash.cpp
@@ -258,6 +258,7 @@ void Hash::visit(const ImportEntry& import_entry) {
   this->process(import_entry.iat_value());
   this->process(import_entry.name());
   this->process(import_entry.data());
+  this->process(import_entry.manually_added());
 }
 
 void Hash::visit(const ResourceNode& resource_node) {

--- a/src/PE/json.cpp
+++ b/src/PE/json.cpp
@@ -462,6 +462,7 @@ void JsonVisitor::visit(const ImportEntry& import_entry) {
   this->node_["iat_address"] = import_entry.iat_address();
   this->node_["data"]        = import_entry.data();
   this->node_["hint"]        = import_entry.hint();
+  this->node_["manually_added"] = import_entry.manually_added();
 }
 
 void JsonVisitor::visit(const ResourceData& resource_data) {


### PR DESCRIPTION
Hi

This pull request fixes the issue (#517).

The current implementation of `build_import_table` does not check the correspondence between the imported functions and the trampolines. So, if we add an import function entry by `add_entry` and build IAT by calling `build_import_table`, its correspondence is shifted back one by one.

I illustrate this situation.

Before adding a new import entry, the correspondence between IAT and trampolines is correct.

![図1](https://user-images.githubusercontent.com/5129526/105137211-5063a000-5b36-11eb-857d-4e3f339224e6.png)

However, after adding `wcsrchr` (illustrated by orange color), its correspondence is incorrect. In this case, when we try to call `puts` function, `_cexit` function is called instead.

![図2](https://user-images.githubusercontent.com/5129526/105137278-65d8ca00-5b36-11eb-957c-9a0b56e064de.png)

To fix this issue, I added a new member `manually_added_` to `ImportEntry` class to distinguish whether the entry is manually added or not. If the entry is a manually-added one, linking between the original IAT entry and the trampoline is skipped.