### PR TITLE
api-c: Protect bool typedef from duplicate declaration.

### DIFF
--- a/api/c/include/LIEF/types.h
+++ b/api/c/include/LIEF/types.h
@@ -17,6 +17,8 @@
 #define LIEF_C_TYPES_H_
 #include <stdint.h>
 #ifndef __cplusplus
+#ifndef bool
 typedef int bool;
+#endif
 #endif
 #endif


### PR DESCRIPTION
bool is defined as a macro since C99.