### PR TITLE
Fix parse_dynamic_entries to stop iterating at DT_NULL

### DIFF
--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -1112,6 +1112,7 @@ void Parser::parse_dynamic_entries(uint64_t offset, uint64_t size) {
 
   Elf_Off dynamic_string_offset = this->get_dynamic_string_table();
 
+  bool end_of_dynamic_section = false;
   this->stream_->setpos(offset);
   for (size_t dynIdx = 0; dynIdx < nb_entries; ++dynIdx) {
     if (not this->stream_->can_read<Elf_Dyn>()) {
@@ -1190,6 +1191,12 @@ void Parser::parse_dynamic_entries(uint64_t offset, uint64_t size) {
           break;
         }
 
+      case DYNAMIC_TAGS::DT_NULL:
+        {
+          end_of_dynamic_section = true;
+          break;
+        }
+
       default:
         {
           dynamic_entry = std::unique_ptr<DynamicEntry>{new DynamicEntry{&entry}};
@@ -1200,6 +1207,10 @@ void Parser::parse_dynamic_entries(uint64_t offset, uint64_t size) {
       this->binary_->dynamic_entries_.push_back(dynamic_entry.release());
     } else {
       LIEF_WARN("dynamic_entry is nullptr !");
+    }
+
+    if (end_of_dynamic_section) {
+      break;
     }
 
   }

--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -1112,7 +1112,7 @@ void Parser::parse_dynamic_entries(uint64_t offset, uint64_t size) {
 
   Elf_Off dynamic_string_offset = this->get_dynamic_string_table();
 
-  bool end_of_dynamic_section = false;
+  bool end_of_dynamic = false;
   this->stream_->setpos(offset);
   for (size_t dynIdx = 0; dynIdx < nb_entries; ++dynIdx) {
     if (not this->stream_->can_read<Elf_Dyn>()) {
@@ -1193,7 +1193,7 @@ void Parser::parse_dynamic_entries(uint64_t offset, uint64_t size) {
 
       case DYNAMIC_TAGS::DT_NULL:
         {
-          end_of_dynamic_section = true;
+          end_of_dynamic = true;
           break;
         }
 
@@ -1209,7 +1209,7 @@ void Parser::parse_dynamic_entries(uint64_t offset, uint64_t size) {
       LIEF_WARN("dynamic_entry is nullptr !");
     }
 
-    if (end_of_dynamic_section) {
+    if (end_of_dynamic) {
       break;
     }
 

--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -1193,6 +1193,7 @@ void Parser::parse_dynamic_entries(uint64_t offset, uint64_t size) {
 
       case DYNAMIC_TAGS::DT_NULL:
         {
+          dynamic_entry = std::unique_ptr<DynamicEntry>{new DynamicEntry{&entry}};
           end_of_dynamic = true;
           break;
         }

--- a/tests/elf/test_parser.py
+++ b/tests/elf/test_parser.py
@@ -67,7 +67,7 @@ class TestSimple(TestCase):
 
     def test_dynamic(self):
         entries = self.binall.dynamic_entries
-        self.assertEqual(len(entries), 32)
+        self.assertEqual(len(entries), 28)
         self.assertEqual(entries[0].name, "libc.so.6")
         self.assertEqual(entries[3].array, [2208, 1782])
         self.assertEqual(self.binall[lief.ELF.DYNAMIC_TAGS.FLAGS_1].value, 0x8000000)


### PR DESCRIPTION
Previously, parse_dynamic_entries iterates the entire dynamic segment.
Ideally, it needs to only iterate dynamic section for dynamic entries.
This fix uses DT_NULL, which marks end of dynamic section.