### PR TITLE
add RISC-V machine type

### DIFF
--- a/api/python/ELF/pyEnums.cpp
+++ b/api/python/ELF/pyEnums.cpp
@@ -254,6 +254,7 @@ void init_enums(py::module& m) {
     .value(PY_ENUM(ARCH::EM_NORC))
     .value(PY_ENUM(ARCH::EM_CSR_KALIMBA))
     .value(PY_ENUM(ARCH::EM_AMDGPU))
+    .value(PY_ENUM(ARCH::EM_RISCV))
     .value(PY_ENUM(ARCH::EM_BPF));
 
 

--- a/include/LIEF/ELF/enums.inc
+++ b/include/LIEF/ELF/enums.inc
@@ -221,6 +221,7 @@ enum _LIEF_EN(ARCH) {
   _LIEF_EI(EM_NORC)          = 218, /**< Nanoradio Optimized RISC */
   _LIEF_EI(EM_CSR_KALIMBA)   = 219, /**< CSR Kalimba architecture family */
   _LIEF_EI(EM_AMDGPU)        = 224, /**< AMD GPU architecture */
+  _LIEF_EI(EM_RISCV)         = 243, /**< RISC-V */
   _LIEF_EI(EM_BPF)           = 247  /**< eBPF Filter */
 };
 

--- a/include/LIEF/ELF/undef.h
+++ b/include/LIEF/ELF/undef.h
@@ -230,6 +230,7 @@
 #undef EM_NORC
 #undef EM_CSR_KALIMBA
 #undef EM_AMDGPU
+#undef EM_RISCV
 #undef EM_BPF
 
 

--- a/src/ELF/EnumToString.cpp
+++ b/src/ELF/EnumToString.cpp
@@ -60,7 +60,7 @@ const char* to_string(VERSION e) {
 
 
 const char* to_string(ARCH e) {
-  CONST_MAP(ARCH, const char*, 176) enumStrings {
+  CONST_MAP(ARCH, const char*, 177) enumStrings {
     { ARCH::EM_NONE,          "None" },
     { ARCH::EM_M32,           "M32"},
     { ARCH::EM_SPARC,         "SPARC"},
@@ -236,6 +236,7 @@ const char* to_string(ARCH e) {
     { ARCH::EM_NORC,          "NORC"},
     { ARCH::EM_CSR_KALIMBA,   "CSR_KALIMBA"},
     { ARCH::EM_AMDGPU,        "AMDGPU"},
+    { ARCH::EM_RISCV,         "RISCV"},
     { ARCH::EM_BPF,           "BPF"}
   };
   auto   it  = enumStrings.find(e);


### PR DESCRIPTION
Similar to #486, add the RISCV machine type to the ELF_ARCH enums.

`EM_RISCV` `243` `RISC-V` as per http://www.sco.com/developers/gabi/latest/ch4.eheader.html.