### PR TITLE
Remove usage of "not" in public headers

### DIFF
--- a/include/LIEF/associative_iterators.hpp
+++ b/include/LIEF/associative_iterators.hpp
@@ -65,7 +65,7 @@ struct dict_iterator_pair {
     return const_cast<add_const_t<key_ref_t>>(this->key_);
   }
 
-  typename std::enable_if<not std::is_const<key_ref_t>::value, remove_const_t<key_ref_t>>::type
+  typename std::enable_if<!std::is_const<key_ref_t>::value, remove_const_t<key_ref_t>>::type
   key(void) const {
     return const_cast<remove_const_t<key_ref_t>>(static_cast<const dict_iterator_pair*>(this)->key());
   }
@@ -74,7 +74,7 @@ struct dict_iterator_pair {
     return const_cast<add_const_t<value_ref_t>>(*this->value_);
   }
 
-  typename std::enable_if<not std::is_const<value_ref_t>::value, remove_const_t<value_ref_t>>::type
+  typename std::enable_if<!std::is_const<value_ref_t>::value, remove_const_t<value_ref_t>>::type
   value(void) const {
     return const_cast<remove_const_t<value_ref_t>>(static_cast<const dict_iterator_pair*>(this)->value());
   }
@@ -185,7 +185,7 @@ class dict_iterator : public std::iterator<
   }
 
 
-  //typename std::enable_if<not std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
+  //typename std::enable_if<!std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
   //operator[](size_t n) {
   //  return const_cast<remove_const_t<ref_t>>(static_cast<const dict_iterator*>(this)->operator[](n));
   //}
@@ -225,12 +225,12 @@ class dict_iterator : public std::iterator<
 
 
   bool operator>=(const dict_iterator& rhs) const {
-    return not (*this < rhs);
+    return !(*this < rhs);
   }
 
 
   bool operator<=(const dict_iterator& rhs) const {
-    return not (*this > rhs);
+    return !(*this > rhs);
   }
 
   dict_iterator begin(void) const {
@@ -257,7 +257,7 @@ class dict_iterator : public std::iterator<
   }
 
   bool operator!=(const dict_iterator& other) const {
-    return not (*this == other);
+    return !(*this == other);
   }
 
   size_t size(void) const {
@@ -265,7 +265,7 @@ class dict_iterator : public std::iterator<
   }
 
 
-  typename std::enable_if<not std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
+  typename std::enable_if<!std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
   operator*() {
     return const_cast<remove_const_t<ref_t>>(static_cast<const dict_iterator*>(this)->operator*());
   }
@@ -278,13 +278,13 @@ class dict_iterator : public std::iterator<
   }
 
   template<typename U = typename DT::value_type>
-  typename std::enable_if<not std::is_pointer<U>::value, add_const_t<ref_t>>::type
+  typename std::enable_if<!std::is_pointer<U>::value, add_const_t<ref_t>>::type
   operator*() const {
     return const_cast<add_const_t<ref_t>>(*(this->it_));
   }
 
 
-  typename std::enable_if<not std::is_const<pointer_t>::value, pointer_t>::type
+  typename std::enable_if<!std::is_const<pointer_t>::value, pointer_t>::type
   operator->() {
     return const_cast<remove_const_t<pointer_t>>(static_cast<const ref_iterator*>(this)->operator->());
   }

--- a/include/LIEF/iterators.hpp
+++ b/include/LIEF/iterators.hpp
@@ -124,7 +124,7 @@ class ref_iterator : public std::iterator<
   }
 
 
-  typename std::enable_if<not std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
+  typename std::enable_if<!std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
   operator[](size_t n) {
     return const_cast<remove_const_t<ref_t>>(static_cast<const ref_iterator*>(this)->operator[](n));
   }
@@ -174,12 +174,12 @@ class ref_iterator : public std::iterator<
 
 
   bool operator>=(const ref_iterator& rhs) const {
-    return not (*this < rhs);
+    return !(*this < rhs);
   }
 
 
   bool operator<=(const ref_iterator& rhs) const {
-    return not (*this > rhs);
+    return !(*this > rhs);
   }
 
   ref_iterator begin(void) const {
@@ -206,7 +206,7 @@ class ref_iterator : public std::iterator<
   }
 
   bool operator!=(const ref_iterator& other) const {
-    return not (*this == other);
+    return !(*this == other);
   }
 
   size_t size(void) const {
@@ -214,7 +214,7 @@ class ref_iterator : public std::iterator<
   }
 
 
-  typename std::enable_if<not std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
+  typename std::enable_if<!std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
   operator*() {
     return const_cast<remove_const_t<ref_t>>(static_cast<const ref_iterator*>(this)->operator*());
   }
@@ -227,13 +227,13 @@ class ref_iterator : public std::iterator<
   }
 
   template<typename U = typename DT::value_type>
-  typename std::enable_if<not std::is_pointer<U>::value, add_const_t<ref_t>>::type
+  typename std::enable_if<!std::is_pointer<U>::value, add_const_t<ref_t>>::type
   operator*() const {
     return const_cast<add_const_t<ref_t>>(*(this->it_));
   }
 
 
-  typename std::enable_if<not std::is_const<pointer_t>::value, pointer_t>::type
+  typename std::enable_if<!std::is_const<pointer_t>::value, pointer_t>::type
   operator->() {
     return const_cast<remove_const_t<pointer_t>>(static_cast<const ref_iterator*>(this)->operator->());
   }
@@ -283,7 +283,7 @@ class filter_iterator : public std::iterator<
     this->it_ = std::begin(this->container_);
 
     if (this->it_ != std::end(this->container_)) {
-      if (not std::all_of(std::begin(this->filters_), std::end(this->filters_), [this] (const filter_t& f) {return f(*this->it_);})) {
+      if (!std::all_of(std::begin(this->filters_), std::end(this->filters_), [this] (const filter_t& f) {return f(*this->it_);})) {
         this->next();
       }
     }
@@ -299,7 +299,7 @@ class filter_iterator : public std::iterator<
     this->it_ = std::begin(this->container_);
 
     if (this->it_ != std::end(this->container_)) {
-      if (not std::all_of(std::begin(this->filters_), std::end(this->filters_), [this] (const filter_t& f) {return f(*this->it_);})) {
+      if (!std::all_of(std::begin(this->filters_), std::end(this->filters_), [this] (const filter_t& f) {return f(*this->it_);})) {
         this->next();
       }
     }
@@ -377,7 +377,7 @@ class filter_iterator : public std::iterator<
     return this->end();
   }
 
-  typename std::enable_if<not std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
+  typename std::enable_if<!std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
   operator*() {
     return const_cast<remove_const_t<ref_t>>(static_cast<const filter_iterator*>(this)->operator*());
   }
@@ -390,13 +390,13 @@ class filter_iterator : public std::iterator<
   }
 
   template<typename U = typename DT::value_type>
-  typename std::enable_if<not std::is_pointer<U>::value, add_const_t<ref_t>>::type
+  typename std::enable_if<!std::is_pointer<U>::value, add_const_t<ref_t>>::type
   operator*() const {
     return const_cast<add_const_t<ref_t>>(*(this->it_));
   }
 
 
-  typename std::enable_if<not std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
+  typename std::enable_if<!std::is_const<ref_t>::value, remove_const_t<ref_t>>::type
   operator[](size_t n) {
     return const_cast<remove_const_t<ref_t>>(static_cast<const filter_iterator*>(this)->operator[](n));
   }
@@ -410,7 +410,7 @@ class filter_iterator : public std::iterator<
   }
 
 
-  typename std::enable_if<not std::is_const<pointer_t>::value, pointer_t>::type
+  typename std::enable_if<!std::is_const<pointer_t>::value, pointer_t>::type
   operator->() {
     return const_cast<remove_const_t<pointer_t>>(static_cast<const filter_iterator*>(this)->operator->());
   }
@@ -442,7 +442,7 @@ class filter_iterator : public std::iterator<
   }
 
   bool operator!=(const filter_iterator& other) const {
-    return not (*this == other);
+    return !(*this == other);
   }
 
   protected:
@@ -457,7 +457,7 @@ class filter_iterator : public std::iterator<
       this->distance_++;
     } while(
         this->it_ != std::end(this->container_) and
-        not std::all_of(
+        !std::all_of(
           std::begin(this->filters_),
           std::end(this->filters_),
           [this] (const filter_t& f) {


### PR DESCRIPTION
This unfortunately makes compilation of project using LIEF with
cl.exe-like compilers really painful. Including "iso646.h" seems like a
hack, and does not seem to work with recent VS2019 versions.