### PR TITLE
resolution for LIEF issue #418

### DIFF
--- a/src/ELF/Binary.tcc
+++ b/src/ELF/Binary.tcc
@@ -242,7 +242,7 @@ void Binary::patch_addend(Relocation& relocation, uint64_t from, uint64_t shift)
     return;
   }
 
-  if (relative_offset >= segment_size or (relative_offset + sizeof(T)) >= segment_size) {
+  if (relative_offset >= segment_size or (relative_offset + sizeof(T)) > segment_size) {
     LIEF_DEBUG("Offset out of bound for relocation: {}", relocation);
     return;
   }


### PR DESCRIPTION
addresses boundary scenario for relocations whose
relative offsets abut segment_size

Apologies for my miscommunication re: _relocations_ with @romainthomas -- this waylaid the resolution which @romainthomas had speculated.

While 64b compilation did not express same run-time failure as 32b, both 32b and 64b relocation content `value`s do not reflect the `shift`s prior to this change.

Tested on scenario described in this comment and successfully addresses 32b runtime issue - and benign to 64b.
https://github.com/lief-project/LIEF/issues/418#issuecomment-657779791

