### PR TITLE
Fix sizeof_headers computing

### DIFF
--- a/src/PE/Binary.cpp
+++ b/src/PE/Binary.cpp
@@ -549,8 +549,8 @@ uint32_t Binary::sizeof_headers(void) const {
     size += sizeof(pe64_optional_header);
   }
 
-  size += sizeof(pe_data_directory) * (this->data_directories_.size() + 1);
-  size += sizeof(pe_section) * (this->sections_.size() + 1);
+  size += sizeof(pe_data_directory) * (this->data_directories_.size());
+  size += sizeof(pe_section) * (this->sections_.size());
   size = static_cast<uint32_t>(LIEF::align(size, this->optional_header().file_alignment()));
   return size;
 


### PR DESCRIPTION
This PR will be fix #569.
Currently, in `Binary::sizeof_headers` method (https://github.com/lief-project/LIEF/blob/master/src/PE/Binary.cpp#L542-L557), `this->data_directories_.size()` and `this->sections_.size()` are added 1.
```
  size += sizeof(pe_data_directory) * (this->data_directories_.size() + 1);
  size += sizeof(pe_section) * (this->sections_.size() + 1);
```
I think these "+1" are unnecessary.

Indeed, the file 7152c6554215cabb53c75d1cd7d988c10351958fb7d190625e6875e3ce57756e (described in the issue #569) has its header whose size is 1f0, but the current computation result is 220, and `Binary::sizeof_headers` returns 400 by `LIEF::align`. So `pe_builder` program produces an invalid PE file from the file.

By removing "+1", `Binary::sizeof_headers` returns 200 properly, and `pe_builder` program produces the same PE file (whose sha256 hash value is 7152c6554215cabb53c75d1cd7d988c10351958fb7d190625e6875e3ce57756e) from the file.