### PR TITLE
MachO: Memoize Symbols by address and name during parsing

### DIFF
--- a/include/LIEF/MachO/BinaryParser.hpp
+++ b/include/LIEF/MachO/BinaryParser.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <limits>
 #include <set>
+#include <map>
 
 #include "LIEF/types.hpp"
 #include "LIEF/visibility.h"
@@ -123,12 +124,14 @@ class LIEF_API BinaryParser : public LIEF::Parser {
 
   void parse_export_trie(uint64_t start, uint64_t end, const std::string& prefix);
 
-  std::unique_ptr<BinaryStream> stream_;
-  Binary*                       binary_{nullptr};
-  MACHO_TYPES                   type_;
-  bool                          is64_;
-  ParserConfig                  config_;
-  std::set<uint64_t>            visited_;
+  std::unique_ptr<BinaryStream>  stream_;
+  Binary*                        binary_{nullptr};
+  MACHO_TYPES                    type_;
+  bool                           is64_;
+  ParserConfig                   config_;
+  std::set<uint64_t>             visited_;
+  std::map<std::string, Symbol*> memoized_symbols_;
+  std::map<uint64_t, Symbol*>    memoized_symbols_by_address_;
 };
 
 

--- a/src/MachO/BinaryParser.cpp
+++ b/src/MachO/BinaryParser.cpp
@@ -137,7 +137,13 @@ void BinaryParser::parse_export_trie(uint64_t start, uint64_t end, const std::st
 
     const std::string& symbol_name = prefix;
     std::unique_ptr<ExportInfo> export_info{new ExportInfo{0, flags, offset}};
-    Symbol* symbol = this->binary_->get_symbol(symbol_name);
+    Symbol* symbol = nullptr;
+    auto search = this->memoized_symbols_.find(symbol_name);
+    if (search != this->memoized_symbols_.end()) {
+      symbol = search->second;
+    } else {
+      symbol = this->binary_->get_symbol(symbol_name);
+    }
     if (symbol != nullptr) {
       export_info->symbol_ = symbol;
       symbol->export_info_ = export_info.get();
@@ -167,7 +173,13 @@ void BinaryParser::parse_export_trie(uint64_t start, uint64_t end, const std::st
         imported_name = export_info->symbol().name();
       }
 
-      Symbol* symbol = this->binary_->get_symbol(imported_name);
+      Symbol* symbol = nullptr;
+      auto search = this->memoized_symbols_.find(imported_name);
+      if (search != this->memoized_symbols_.end()) {
+        symbol = search->second;
+      } else {
+        symbol = this->binary_->get_symbol(imported_name);
+      }
       if (symbol != nullptr) {
         export_info->alias_ = symbol;
         symbol->export_info_ = export_info.get();


### PR DESCRIPTION
I was having really long runtimes like also reported in https://github.com/lief-project/LIEF/issues/442 . Actually, my issue is exactly what is covered in https://github.com/conda/conda-build/issues/3684 . Profiling lead to most of the runtime being spent in `Binary::get_symbol` and `BinaryParser::do_bind` (these were actually the only functions visible by eye in the profiling plot). For me the runtime of `lief.parse(…)` goes down as follows for the example of the haskell compiler:

| file | size | time in s (before) | time in s (this PR) |
| --- | --- | -- | -- |
| `libHSbase-4.14.1.0-ghc8.10.4.dylib` | 12M | 47 | 0.2 |
| `libHSghc-8.10.4-ghc8.10.4.dylib` | 97M | 3161 | 1.4 |