### PR TITLE
Add str escape

### DIFF
--- a/src/PE/ResourcesManager.cpp
+++ b/src/PE/ResourcesManager.cpp
@@ -608,10 +608,15 @@ ResourceStringFileInfo ResourcesManager::get_string_file_info(const VectorStream
     if (key.length() != 8) {
       LIEF_ERR("Corrupted key ({} {})", u16tou8(key), key_str);
     } else {
-      uint64_t lang_id   = std::stoul(u16tou8(key.substr(0, 4)), 0, 16);
-      uint64_t code_page = std::stoul(u16tou8(key.substr(4, 8)), 0, 16);
-      LIEF_DEBUG("Lang ID: {:d}", lang_id);
-      LIEF_DEBUG("Code page: 0x{:x}", code_page);
+      try {
+        uint64_t lang_id   = std::stoul(u16tou8(key.substr(0, 4)), 0, 16);
+        uint64_t code_page = std::stoul(u16tou8(key.substr(4, 8)), 0, 16);
+        LIEF_DEBUG("Lang ID: {:d}", lang_id);
+        LIEF_DEBUG("Code page: 0x{:x}", code_page);
+      } catch (const std::invalid_argument& e) {
+        LIEF_WARN("Cannot convert to integer");
+        LIEF_WARN("This PE file has Invalid Lang ID or Code page");
+      }
     }
 
     stream.align(sizeof(uint32_t));

--- a/src/PE/json.cpp
+++ b/src/PE/json.cpp
@@ -605,8 +605,8 @@ void JsonVisitor::visit(const ResourcesManager& resources_manager) {
         JsonVisitor accelerator_visitor;
         accelerator_visitor(acc);
         accelerator_json.emplace_back(accelerator_visitor.get());
-        this->node_["accelerator"] = accelerator_json;
       }
+      this->node_["accelerator"] = accelerator_json;
     } catch (const LIEF::exception& e) {
       LIEF_WARN("{}", e.what());
     }

--- a/src/PE/json.cpp
+++ b/src/PE/json.cpp
@@ -591,8 +591,8 @@ void JsonVisitor::visit(const ResourcesManager& resources_manager) {
         JsonVisitor string_table_visitor;
         string_table_visitor(string_table);
         string_table_json.emplace_back(string_table_visitor.get());
-        this->node_["string_table"] = string_table_json;
       }
+      this->node_["string_table"] = string_table_json;
     } catch (const LIEF::exception& e) {
       LIEF_WARN("{}", e.what());
     }

--- a/src/PE/json.cpp
+++ b/src/PE/json.cpp
@@ -390,7 +390,7 @@ void JsonVisitor::visit(const Symbol& symbol) {
 
   this->node_["value"]                = symbol.value();
   this->node_["size"]                 = symbol.size();
-  this->node_["name"]                 = symbol.name();
+  this->node_["name"]                 = escape_non_ascii(symbol.name());
 
   this->node_["section_number"]       = symbol.section_number();
   this->node_["type"]                 = symbol.type();
@@ -536,7 +536,11 @@ void JsonVisitor::visit(const ResourcesManager& resources_manager) {
 
   if (resources_manager.has_html()) {
     try {
-      this->node_["html"] = resources_manager.html();
+      std::vector<std::string> escaped_strs;
+      for (const auto& elem : resources_manager.html()) {
+        escaped_strs.emplace_back(escape_non_ascii(elem));
+      }
+      this->node_["html"] = escaped_strs;
     } catch (const LIEF::exception& e) {
       LIEF_WARN("{}", e.what());
     }


### PR DESCRIPTION
Hi, @romainthomas 

This pull-request fixes minor bugs while calling `to_json` and `ResourcesManager::get_string_file_info` for some PE files.

When non-ascii strings are included in the `lief.to_json` output, the call of `lief.to_json` will crash.
For example, since [this sample](https://www.virustotal.com/gui/file/6a09aef6b70071154e2eba268f5aa3ab342d9e9ecdc6d7a6a5d3c7499d98c5bd/details) contains the non-ascii string in the name filed of symbol, we cannot get the json output of `lief.to_json`. To void this, I added `escape_nonascii` function call to escape non-ascii strings.

Additionally, the current implementation of `ResourcesManager::get_string_file_info` does not catch the exceptions of the `stoul` when passing non-integer string. I added an try-except block to catch these exceptions.