### PR TITLE
MachO bug fix: lief.MachO.BindingInfo.library analyze wrong

### DIFF
--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -772,8 +772,9 @@ LoadCommand& Binary::add(const LoadCommand& command) {
 
   this->commands_.push_back(copy);
 
-  // Update cache
-  if (typeid(*copy) == typeid(DylibCommand)) {
+  // Update cache  
+  if (typeid(*copy) == typeid(DylibCommand) 
+      && dynamic_cast<DylibCommand*>(copy)->command() != LOAD_COMMAND_TYPES::LC_ID_DYLIB) {
     this->libraries_.push_back(reinterpret_cast<DylibCommand*>(copy));
   }
 
@@ -824,7 +825,8 @@ LoadCommand& Binary::add(const LoadCommand& command, size_t index) {
     }
   }
 
-  if (typeid(*copy) == typeid(DylibCommand)) {
+  if (typeid(*copy) == typeid(DylibCommand) 
+      && dynamic_cast<DylibCommand*>(copy)->command() != LOAD_COMMAND_TYPES::LC_ID_DYLIB) {
     this->libraries_.push_back(reinterpret_cast<DylibCommand*>(copy));
   }
 

--- a/src/MachO/BinaryParser.tcc
+++ b/src/MachO/BinaryParser.tcc
@@ -199,7 +199,6 @@ void BinaryParser::parse_load_commands(void) {
       // DyLib Command
       // =============
       case LOAD_COMMAND_TYPES::LC_LOAD_WEAK_DYLIB:
-      case LOAD_COMMAND_TYPES::LC_ID_DYLIB:
       case LOAD_COMMAND_TYPES::LC_LOAD_DYLIB:
       case LOAD_COMMAND_TYPES::LC_REEXPORT_DYLIB:
       case LOAD_COMMAND_TYPES::LC_LOAD_UPWARD_DYLIB:


### PR DESCRIPTION
There is no need to add `LC_ID_DYLIB` command into `binary_->libraries_`, which can cause the analysis result of `lief.MachO.BindingInfo.library` wrong.

Referring to [llvm /lib/Object/MachOObjectFile.cpp src](https://github.com/llvm-mirror/llvm/blob/2c4ca6832fa6b306ee6a7010bfb80a3f2596f824/lib/Object/MachOObjectFile.cpp#L1401),  it is obvious that LLVM filters the library of LC_ID_DYLIB command.