### PR TITLE
Fix DEX prototype parameters type parsing

### DIFF
--- a/src/DEX/Parser.tcc
+++ b/src/DEX/Parser.tcc
@@ -249,10 +249,10 @@ void Parser::parse_prototypes(void) {
       size_t nb_params = this->stream_->read<uint32_t>();
 
       for (size_t i = 0; i < nb_params; ++i) {
-        if (not this->stream_->can_read<uint32_t>()) {
+        if (not this->stream_->can_read<uint16_t>()) {
           break;
         }
-        uint32_t type_idx = this->stream_->read<uint32_t>();
+        uint16_t type_idx = this->stream_->read<uint16_t>();
 
         if (type_idx > this->file_->types_.size()) {
           break;


### PR DESCRIPTION
This pull request fixes DEX prototype parameters type parsing bug. Each `param_type` takes 16 bits, not 32 bits. Without this fix, `prototype->params_.size()` is always 0 or 1, which is usually wrong and different from `nb_params`.
See: Dex::TypeList in [kaitai formats: DEX](http://formats.kaitai.io/dex/dex.svg), TYPE LIST in [corkami pics: DEX](https://raw.githubusercontent.com/corkami/pics/master/binary/DEX.png)