### PR TITLE
Fix broken python API doc for Android formats

### DIFF
--- a/api/python/ART/objects/pyParser.cpp
+++ b/api/python/ART/objects/pyParser.cpp
@@ -28,13 +28,13 @@ void create<Parser>(py::module& m) {
   // Parser (Parser)
   m.def("parse",
     static_cast<std::unique_ptr<File> (*) (const std::string&)>(&Parser::parse),
-    "Parse the given filename and return an " RST_CLASS_REF(lief.ART.File) " object"
+    "Parse the given filename and return an " RST_CLASS_REF(lief.ART.File) " object",
     "filename"_a,
     py::return_value_policy::take_ownership);
 
   m.def("parse",
     static_cast<std::unique_ptr<File> (*) (const std::vector<uint8_t>&, const std::string&)>(&Parser::parse),
-    "Parse the given raw data and return an " RST_CLASS_REF(lief.ART.File) " object\n\n"
+    "Parse the given raw data and return an " RST_CLASS_REF(lief.ART.File) " object",
     "raw"_a, py::arg("name") = "",
     py::return_value_policy::take_ownership);
 

--- a/api/python/DEX/objects/pyParser.cpp
+++ b/api/python/DEX/objects/pyParser.cpp
@@ -27,13 +27,13 @@ void create<Parser>(py::module& m) {
 
   m.def("parse",
     static_cast<std::unique_ptr<File> (*) (const std::string&)>(&Parser::parse),
-    "Parse the given filename and return a " RST_CLASS_REF(lief.DEX.File) " object"
+    "Parse the given filename and return a " RST_CLASS_REF(lief.DEX.File) " object",
     "filename"_a,
     py::return_value_policy::take_ownership);
 
   m.def("parse",
     static_cast<std::unique_ptr<File> (*) (const std::vector<uint8_t>&, const std::string&)>(&Parser::parse),
-    "Parse the given raw data and return a " RST_CLASS_REF(lief.DEX.File) " object\n\n"
+    "Parse the given raw data and return a " RST_CLASS_REF(lief.DEX.File) " object",
     "raw"_a, py::arg("name") = "",
     py::return_value_policy::take_ownership);
 

--- a/api/python/DEX/pyUtils.cpp
+++ b/api/python/DEX/pyUtils.cpp
@@ -24,7 +24,7 @@ void init_utils(py::module& m) {
 
   m.def("is_dex",
       static_cast<bool (*)(const std::string&)>(&is_dex),
-      "Check if the **file** given in parameter is an DDEX",
+      "Check if the **file** given in parameter is a DEX",
       "path"_a);
 
   m.def("is_dex",

--- a/api/python/OAT/objects/pyParser.cpp
+++ b/api/python/OAT/objects/pyParser.cpp
@@ -28,19 +28,19 @@ void create<Parser>(py::module& m) {
   // Parser (Parser)
   m.def("parse",
     static_cast<std::unique_ptr<Binary> (*) (const std::string&)>(&Parser::parse),
-    "Parse the given OAT file and return a " RST_CLASS_REF(lief.OAT.Binary) " object"
+    "Parse the given OAT file and return a " RST_CLASS_REF(lief.OAT.Binary) " object",
     "oat_file"_a,
     py::return_value_policy::take_ownership);
 
   m.def("parse",
     static_cast<std::unique_ptr<Binary> (*) (const std::string&, const std::string&)>(&Parser::parse),
-    "Parse the given OAT with its VDEX file and return a " RST_CLASS_REF(lief.OAT.Binary) " object"
+    "Parse the given OAT with its VDEX file and return a " RST_CLASS_REF(lief.OAT.Binary) " object",
     "oat_file"_a, "vdex_file"_a,
     py::return_value_policy::take_ownership);
 
   m.def("parse",
     static_cast<std::unique_ptr<Binary> (*) (const std::vector<uint8_t>&, const std::string&)>(&Parser::parse),
-    "Parse the given raw data and return a " RST_CLASS_REF(lief.OAT.Binary) " object\n\n"
+    "Parse the given raw data and return a " RST_CLASS_REF(lief.OAT.Binary) " object",
     "raw"_a, py::arg("name") = "",
     py::return_value_policy::take_ownership);
 

--- a/api/python/VDEX/objects/pyParser.cpp
+++ b/api/python/VDEX/objects/pyParser.cpp
@@ -28,13 +28,13 @@ void create<Parser>(py::module& m) {
   // Parser (Parser)
   m.def("parse",
     static_cast<std::unique_ptr<File> (*) (const std::string&)>(&Parser::parse),
-    "Parse the given filename and return a " RST_CLASS_REF(lief.VDEX.File) " object"
+    "Parse the given filename and return a " RST_CLASS_REF(lief.VDEX.File) " object",
     "filename"_a,
     py::return_value_policy::take_ownership);
 
   m.def("parse",
     static_cast<std::unique_ptr<File> (*) (const std::vector<uint8_t>&, const std::string&)>(&Parser::parse),
-    "Parse the given raw data and return a " RST_CLASS_REF(lief.VDEX.File) " object\n\n"
+    "Parse the given raw data and return a " RST_CLASS_REF(lief.VDEX.File) " object",
     "raw"_a, py::arg("name") = "",
     py::return_value_policy::take_ownership);
 


### PR DESCRIPTION
This pull request fixes the broken python API doc for Android formats. The missing comma in `pyParser.cpp` results in unexpected behavior in the Python documentation.
Take `lief.DEX.parse` on [LIEF Documentation](https://lief-project.github.io//doc/latest/api/python/dex.html#parser) for example:
<img src="https://user-images.githubusercontent.com/13433549/134518296-45af6be6-a9c1-45db-b2ed-31ddf7995121.png" width="600px" /><br />

With the fix, the generated documentation will become normal:
<br /><img src="https://user-images.githubusercontent.com/13433549/134519292-2f4c1e4f-992a-496c-9b3a-ae9aeea85aa9.png" width="540px"/>
