### PR TITLE
Fix Python API iterator performance issue

### DIFF
--- a/api/python/pyIterators.hpp
+++ b/api/python/pyIterators.hpp
@@ -47,9 +47,9 @@ void init_ref_iterator(py::module& m, const std::string& it_name = typeid(T).nam
         })
 
     .def("__iter__",
-        [](T& v) -> T {
-          return std::begin(v);
-        }, py::return_value_policy::reference_internal)
+        [](const T& v) {
+          return py::make_iterator(std::begin(v), std::end(v));
+        }, py::keep_alive<0, 1>())
 
     .def("__next__",
         [] (T& v) -> typename T::reference {


### PR DESCRIPTION
This pull request aims to fix Python API iterator performance issue by replacing current `__iter__` with Pybind11's `py::make_iterator` and `py::keep_alive`. 

Take [classes.dex](https://github.com/lief-project/tutorials/blob/master/10_android_formats/classes.dex) for example:

Before:

![lanxin_20211013120430](https://user-images.githubusercontent.com/13433549/137065286-debebc02-ddf7-4ddc-aa10-a3f78c0c22e3.png)

After:

![lanxin_20211013120441](https://user-images.githubusercontent.com/13433549/137065313-d7c3644c-7d88-4e3b-aa63-797d97d66bff.png)
