### PR TITLE
Fix memory leak in Android DEX parsing

### DIFF
--- a/src/DEX/Class.cpp
+++ b/src/DEX/Class.cpp
@@ -243,6 +243,7 @@ std::ostream& operator<<(std::ostream& os, const Class& cls) {
     os << " - " << cls.source_filename();
   }
 
+  os << " - " << std::dec << cls.fields().size() << " Fields";
   os << " - " << std::dec << cls.methods().size() << " Methods";
 
   return os;

--- a/src/DEX/File.cpp
+++ b/src/DEX/File.cpp
@@ -592,6 +592,9 @@ File::~File(void) {
     delete str;
   }
 
+  for (Field* field : this->fields_) {
+    delete field;
+  }
 
   for (Type* t : this->types_) {
     delete t;


### PR DESCRIPTION
This pull request aims to fix the memory leak issue in Android DEX parsing. Memory analysis has been performed with valgrind memcheck tool. 
PS: I can upload the valgrind memcheck log if needed.