### PR TITLE
Support setting ELF header identity from bytes

### DIFF
--- a/api/python/ELF/objects/pyHeader.cpp
+++ b/api/python/ELF/objects/pyHeader.cpp
@@ -75,6 +75,11 @@ void create<Header>(py::module& m) {
             return;
           }
 
+          if (py::isinstance<py::bytes>(obj)) {
+            header.identity(obj.cast<Header::identity_t>());
+            return;
+          }
+
           if (py::isinstance<py::list>(obj)) {
             header.identity(obj.cast<Header::identity_t>());
             return;


### PR DESCRIPTION
Hello,
The following Python code currently fails with Python 3.9 (and the [current git `master` of LIEF](https://github.com/lief-project/LIEF/tree/2ae5327e86f50fe87733d8641d4e7bc3774e3087)):

    import lief
    elf = lief.ELF.Binary("test", lief.ELF.ELF_CLASS.CLASS32)
    elf.header.identity = bytes.fromhex("7f454c46010101000000000000000000")

The reported error is:

    TypeError: b'\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00' is not supported!

It is possible to use `.decode()` to convert the bytes to string (in the Python code), or to use `list(...)` to convert them to a list of integers. Both these solutions work, but they are not as elegant as directly using `bytes`.

Modify the `identity` setter to support bytes. As `Header::identity_t` is directly an array of `uint8_t`, casting it from `py::bytes` is straightforward.