### PR TITLE
Add missing array header

### DIFF
--- a/src/BinaryStream/VectorStream.cpp
+++ b/src/BinaryStream/VectorStream.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <array>
 #include <iterator>
 #include <vector>
 #include <string>


### PR DESCRIPTION
This fixes a compilation error on Windows. Encountered during packaging with vcpkg (https://github.com/microsoft/vcpkg/pull/22957)