### PR TITLE
Use CMake BUILD_INTERFACE generator expression for include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/LIEF.pc.in ${CMAKE_CURRENT_BINARY_DIR
                @ONLY)
 
 target_include_directories(LIB_LIEF
-  PUBLIC  "${LIEF_PUBLIC_INCLUDE_DIR}"
+  PUBLIC  "$<BUILD_INTERFACE:${LIEF_PUBLIC_INCLUDE_DIR}>"
   PRIVATE "${LIEF_PRIVATE_INCLUDE_DIR}")
 
 if(LIEF_ENABLE_JSON)
@@ -379,7 +379,7 @@ if(LIEF_EXTERNAL_LEAF)
   if(LIEF_EXTERNAL_LEAF_DIR)
     message(STATUS "External LEAF include dir: ${LIEF_EXTERNAL_LEAF_DIR}")
     target_include_directories(LIB_LIEF SYSTEM PUBLIC
-                               ${LIEF_EXTERNAL_LEAF_DIR})
+                               "$<BUILD_INTERFACE:${LIEF_EXTERNAL_LEAF_DIR}>")
   endif()
 else()
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/LIEF/third-party/internal/leaf.hpp
@@ -422,7 +422,7 @@ if(LIEF_EXTERNAL_SPAN)
   if(LIEF_EXTERNAL_SPAN_DIR)
     message(STATUS "External span include dir: ${LIEF_EXTERNAL_SPAN_DIR}")
     target_include_directories(LIB_LIEF SYSTEM PUBLIC
-                               ${LIEF_EXTERNAL_SPAN_DIR})
+                               "$<BUILD_INTERFACE:${LIEF_EXTERNAL_SPAN_DIR}>")
   endif()
 else()
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/LIEF/third-party/internal/span.hpp

--- a/cmake/LIEFApi.cmake
+++ b/cmake/LIEFApi.cmake
@@ -18,7 +18,7 @@ endif()
 # -----
 if(LIEF_C_API)
   target_include_directories(LIB_LIEF
-    PUBLIC  "${CMAKE_CURRENT_SOURCE_DIR}/api/c/include")
+    PUBLIC  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api/c/include>")
 
   include("${CMAKE_CURRENT_SOURCE_DIR}/api/c/CMakeLists.txt")
 endif()

--- a/cmake/LIEFDependencies.cmake
+++ b/cmake/LIEFDependencies.cmake
@@ -179,7 +179,7 @@ else()
   ExternalProject_get_property(lief_spdlog_project SOURCE_DIR)
   set(SPDLOG_SOURCE_DIR "${SOURCE_DIR}")
   add_dependencies(lief_spdlog lief_spdlog_project)
-  target_include_directories(lief_spdlog SYSTEM INTERFACE ${SPDLOG_SOURCE_DIR}/include)
+  target_include_directories(lief_spdlog SYSTEM INTERFACE "$<BUILD_INTERFACE:${SPDLOG_SOURCE_DIR}/include>")
 endif()
 
 # Frozen


### PR DESCRIPTION
This fixes the paths that are generated for the exported targets so that
they do not have absolute paths that were found/used at build time.

Note: It doesn't look like the generated `LIEFExport.cmake` file is
actually used anywhere, so these changes don't really have any effect
yet, but I am hoping to fix that in an upcoming PR.