### PR TITLE
support for adding and assigning new auxiliary symbol versions

### DIFF
--- a/api/python/ELF/objects/pySymbolVersion.cpp
+++ b/api/python/ELF/objects/pySymbolVersion.cpp
@@ -18,6 +18,7 @@
 #include "LIEF/ELF/SymbolVersion.hpp"
 #include "LIEF/ELF/hash.hpp"
 #include "LIEF/ELF/SymbolVersionAux.hpp"
+#include "LIEF/ELF/SymbolVersionAuxRequirement.hpp"
 
 #include <string>
 #include <sstream>
@@ -70,11 +71,12 @@ void create<SymbolVersion>(py::module& m) {
         &SymbolVersion::has_auxiliary_version,
         "Check if this symbols has a " RST_CLASS_REF(lief.ELF.SymbolVersionAux) "")
 
-    .def_property_readonly(
+    .def_property(
         "symbol_version_auxiliary",
          static_cast<SymbolVersionAux* (SymbolVersion::*)(void)>(&SymbolVersion::symbol_version_auxiliary),
+         static_cast<void (SymbolVersion::*)(SymbolVersionAuxRequirement&)>(&SymbolVersion::symbol_version_auxiliary),
         "Return the " RST_CLASS_REF(lief.ELF.SymbolVersionAux) " associated with this version or "
-        "None if not present",
+        "None if not present. The value can be changed by assigning " RST_CLASS_REF(lief.ELF.SymbolVersionAuxRequirement) "",
         py::return_value_policy::reference_internal)
 
 

--- a/api/python/ELF/objects/pySymbolVersionAuxRequirement.cpp
+++ b/api/python/ELF/objects/pySymbolVersionAuxRequirement.cpp
@@ -34,6 +34,8 @@ using setter_t = void (SymbolVersionAuxRequirement::*)(T);
 template<>
 void create<SymbolVersionAuxRequirement>(py::module& m) {
   py::class_<SymbolVersionAuxRequirement, SymbolVersionAux>(m, "SymbolVersionAuxRequirement")
+    .def(py::init<>(),"Default constructor")
+
     .def_property("hash",
         static_cast<getter_t<uint32_t>>(&SymbolVersionAuxRequirement::hash),
         static_cast<setter_t<uint32_t>>(&SymbolVersionAuxRequirement::hash),

--- a/api/python/ELF/objects/pySymbolVersionRequirement.cpp
+++ b/api/python/ELF/objects/pySymbolVersionRequirement.cpp
@@ -60,6 +60,10 @@ void create<SymbolVersionRequirement>(py::module& m) {
         "Auxiliary entries (iterator over " RST_CLASS_REF(lief.ELF.SymbolVersionAuxRequirement) ")",
         py::return_value_policy::reference_internal)
 
+    .def("add_auxiliary_requirement",
+        static_cast<SymbolVersionAuxRequirement& (SymbolVersionRequirement::*)(SymbolVersionAuxRequirement&)>(&SymbolVersionRequirement::add_aux_requirement),
+        "Add an auxiliary version requirement to the existing entries")
+
     .def("__eq__", &SymbolVersionRequirement::operator==)
     .def("__ne__", &SymbolVersionRequirement::operator!=)
     .def("__hash__",

--- a/include/LIEF/ELF/SymbolVersion.hpp
+++ b/include/LIEF/ELF/SymbolVersion.hpp
@@ -61,6 +61,9 @@ class LIEF_API SymbolVersion : public Object {
   SymbolVersionAux*       symbol_version_auxiliary();
   const SymbolVersionAux* symbol_version_auxiliary() const;
 
+  //! Set the version's auxiliary requirement
+  void symbol_version_auxiliary(SymbolVersionAuxRequirement& symbol_version_aux_requirement);
+
   void value(uint16_t v);
 
   void accept(Visitor& visitor) const override;

--- a/include/LIEF/ELF/SymbolVersionRequirement.hpp
+++ b/include/LIEF/ELF/SymbolVersionRequirement.hpp
@@ -71,6 +71,9 @@ class LIEF_API SymbolVersionRequirement : public Object {
   void version(uint16_t version);
   void name(const std::string& name);
 
+  //! Add a version auxiliary requirement to the existing list
+  SymbolVersionAuxRequirement& add_aux_requirement(SymbolVersionAuxRequirement& aux_requirement);
+
   void accept(Visitor& visitor) const override;
 
   bool operator==(const SymbolVersionRequirement& rhs) const;

--- a/src/ELF/SymbolVersion.cpp
+++ b/src/ELF/SymbolVersion.cpp
@@ -20,6 +20,7 @@
 
 #include "LIEF/ELF/SymbolVersion.hpp"
 #include "LIEF/ELF/SymbolVersionAux.hpp"
+#include "LIEF/ELF/SymbolVersionAuxRequirement.hpp"
 
 namespace LIEF {
 namespace ELF {
@@ -59,6 +60,11 @@ const SymbolVersionAux* SymbolVersion::symbol_version_auxiliary() const {
 
 SymbolVersionAux* SymbolVersion::symbol_version_auxiliary() {
   return const_cast<SymbolVersionAux*>(static_cast<const SymbolVersion*>(this)->symbol_version_auxiliary());
+}
+
+void SymbolVersion::symbol_version_auxiliary(SymbolVersionAuxRequirement& symbol_version_aux_requirement) {
+  symbol_aux_ = (SymbolVersionAux*) &symbol_version_aux_requirement;
+  value_ = symbol_version_aux_requirement.other();
 }
 
 void SymbolVersion::value(uint16_t value) {

--- a/src/ELF/SymbolVersionRequirement.cpp
+++ b/src/ELF/SymbolVersionRequirement.cpp
@@ -97,6 +97,10 @@ void SymbolVersionRequirement::name(const std::string& name) {
   name_ = name;
 }
 
+SymbolVersionAuxRequirement& SymbolVersionRequirement::add_aux_requirement(SymbolVersionAuxRequirement& aux_requirement) {
+  aux_requirements_.push_back(std::make_unique<SymbolVersionAuxRequirement>(aux_requirement));
+  return *aux_requirements_.back();
+}
 
 void SymbolVersionRequirement::accept(Visitor& visitor) const {
   visitor.visit(*this);


### PR DESCRIPTION
This PR has helped me patch an old library. It was built against an old glibc version, and ``pthread_yield`` didn't have an auxiliary symbol version entry. I made it work by adding "GLIBC_2.2".

The use case in Python

```
import lief

filename = "library.so"
lib = lief.parse(filename)

for svr in lib.symbols_version_requirement:
    if svr.name == "libc.so.6":
        ar = lief.ELF.SymbolVersionAuxRequirement()
        ar.other = 12
        ar.name = "GLIBC_2.2"
        sauxr = svr.add_auxiliary_requirement(ar)
        break

for x in lib.dynamic_symbols:
    if x.name == "pthread_yield":
        x.symbol_version.symbol_version_auxiliary = sauxr

lib.write(filename)  
```