### PR TITLE
Fix ELF section inclusion calculations

### DIFF
--- a/src/ELF/Parser.cpp
+++ b/src/ELF/Parser.cpp
@@ -605,18 +605,16 @@ ok_error_t Parser::parse_overlay() {
 }
 
 bool Parser::check_section_in_segment(const Section& section, const Segment& segment) {
-  const uint64_t sec_end = section.virtual_address() + section.size();
   if (section.virtual_address() > 0) {
     const uint64_t seg_vend = segment.virtual_address() + segment.virtual_size();
     return segment.virtual_address() <= section.virtual_address() &&
-           sec_end <= seg_vend;
+           section.virtual_address() + section.size() <= seg_vend;
   }
 
   if (section.file_offset() > 0) {
     const uint64_t seg_end = segment.file_offset() + segment.physical_size();
     return segment.file_offset() <= section.file_offset() &&
-           sec_end < seg_end;
-
+           section.file_offset() + section.size() <= seg_end;
   }
   return false;
 }


### PR DESCRIPTION
ELF section's virtual address was compared with segment physical/file span. It works if section's virtual address is equal to its file offset which is most often true. If it's not, the section may get additional invalid entries on associated segments list. Fixed.

Also, the condition comparing physical/file span ends seems to be missing an '='. Added.