### PR TITLE
Detect data section end's before going ahead on accessing it

### DIFF
--- a/src/PE/Binary.cpp
+++ b/src/PE/Binary.cpp
@@ -1449,7 +1449,12 @@ std::vector<uint8_t> Binary::get_content_from_virtual_address(uint64_t virtual_a
   const uint64_t offset = rva - section->virtual_address();
   uint64_t checked_size = size;
   if ((offset + checked_size) > content.size()) {
-    checked_size = checked_size - (offset + checked_size - content.size());
+    uint64_t delta_off = offset + checked_size - content.size();
+    if (checked_size < delta_off) {
+        LIEF_ERR("Can't access section data due to a section end overflow.");
+        return {};
+    }
+    checked_size = checked_size - delta_off;
   }
 
   return {content.data() + offset, content.data() + offset + checked_size};


### PR DESCRIPTION
Hi there!

This commit is related to this specific [issue](https://github.com/lief-project/LIEF/issues/705). I have obeserved that the adjustment done under the changed if-block was overflowing the unsigned variable ``checked_size`` (it was loaded with a value less than the delta subtracted from it). Being an overflowed value it was making LIEF read more data than it supposed must do. Since I am not totally engaged with the code I decided to avoid the problem by inserting a defensive escape. Anyway, the following problem seems to be occurring with small binaries. Since LIEF is used by security applications it would be good avoid this kind of problem, since it can take the client application down. Checking on the sanity of pointers addresses before accessing them also would be a good defensive measure for the next releases.

I was not able to reproduce the [problem](https://github.com/lief-project/LIEF/issues/705) with the LIEF generated with this proposed patch. You can use the PoC attached to the issue in order to atest it. 

I hope that helps!