### PR TITLE
Fix #712: Guard json includes with LIEF_JSON_SUPPORT

### DIFF
--- a/src/DEX/File.cpp
+++ b/src/DEX/File.cpp
@@ -23,7 +23,9 @@
 #include "LIEF/DEX/hash.hpp"
 #include "DEX/Structures.hpp"
 
+#if defined(LIEF_JSON_SUPPORT)
 #include "visitors/json.hpp"
+#endif
 
 namespace LIEF {
 namespace DEX {

--- a/src/OAT/Binary.cpp
+++ b/src/OAT/Binary.cpp
@@ -22,7 +22,10 @@
 #include "LIEF/OAT/Binary.hpp"
 #include "LIEF/OAT/hash.hpp"
 #include "logging.hpp"
+
+#if defined(LIEF_JSON_SUPPORT)
 #include "visitors/json.hpp"
+#endif
 
 
 namespace LIEF {

--- a/src/VDEX/File.cpp
+++ b/src/VDEX/File.cpp
@@ -17,7 +17,10 @@
 #include "LIEF/VDEX/File.hpp"
 #include "LIEF/VDEX/hash.hpp"
 #include "LIEF/DEX/File.hpp"
+
+#if defined(LIEF_JSON_SUPPORT)
 #include "visitors/json.hpp"
+#endif
 
 namespace LIEF {
 namespace VDEX {


### PR DESCRIPTION
I think this is probably what it should do, at least this builds for me now when I have LIEF_JSON_SUPPORT=Off

Closes #712