### PR TITLE
Correct default for Binary::has_nx on ppc64

### DIFF
--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -1097,7 +1097,12 @@ bool Binary::has_nx() const {
                                        return segment->type() == SEGMENT_TYPES::PT_GNU_STACK;
                                      });
   if (it_stack == std::end(segments_)) {
-    return false;
+    if (header().machine_type() == ARCH::EM_PPC64) {
+      // The PPC64 ELF ABI has a non-executable stack by default.
+      return true;
+    } else {
+      return false;
+    }
   }
 
   return !(*it_stack)->has(ELF_SEGMENT_FLAGS::PF_X);


### PR DESCRIPTION
From the Linux kernel source:

     * This is the default if a program doesn't have a PT_GNU_STACK
     * program header entry. The PPC64 ELF ABI has a non executable stack
     * stack by default, so in the absence of a PT_GNU_STACK program header
     * we turn execute permission off.

Resolve #717