### PR TITLE
Fix ordering of resource node childs in PE

### DIFF
--- a/api/python/PE/objects/pyResourceNode.cpp
+++ b/api/python/PE/objects/pyResourceNode.cpp
@@ -95,10 +95,6 @@ void create<ResourceNode>(py::module& m) {
         "Delete the " RST_CLASS_REF(lief.PE.ResourceNode) " with the given :attr:`~lief.PE.ResourceNode.id` from childs",
         "id"_a)
 
-    .def("sort_by_id",
-        &ResourceNode::sort_by_id,
-        "Sort resource childs by ID")
-
     .def_property_readonly("depth",
         &ResourceNode::depth,
         "Current depth of the entry in the resource tree")

--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -47,6 +47,11 @@ Changelog
 
       sec = bin.remove_section("__DATA", "__objc_metadata")
 
+:PE:
+
+  * Remove :meth:`lief.PE.ResourceNode.sort_by_id`
+  * Fix the ordering of childs of :class:`~lief.PE.ResourceNode`
+
 :General Design:
 
   * Remove the exceptions

--- a/include/LIEF/PE/ResourceNode.hpp
+++ b/include/LIEF/PE/ResourceNode.hpp
@@ -116,9 +116,6 @@ class LIEF_API ResourceNode : public Object {
   //! Delete the given node from the node's children
   void delete_child(const ResourceNode& node);
 
-  //! Sort the resource children by ID
-  void sort_by_id();
-
   void accept(Visitor& visitor) const override;
 
   bool operator==(const ResourceNode& rhs) const;
@@ -128,6 +125,7 @@ class LIEF_API ResourceNode : public Object {
 
   protected:
   ResourceNode();
+  childs_t::iterator insert_child(std::unique_ptr<ResourceNode> child);
   TYPE           type_ = TYPE::UNKNOWN;
   uint32_t       id_ = 0;
   std::u16string name_;

--- a/src/PE/ResourcesManager.cpp
+++ b/src/PE/ResourcesManager.cpp
@@ -605,7 +605,6 @@ void ResourcesManager::add_icon(const ResourceIcon& icon) {
   new_icon_dir_node.add_child(new_icon_data_node);
 
   it_icon->add_child(new_icon_dir_node);
-  it_icon->sort_by_id();
 }
 
 
@@ -682,7 +681,6 @@ void ResourcesManager::change_icon(const ResourceIcon& original, const ResourceI
   new_icon_dir_node.add_child(new_icon_data_node);
 
   it_icon->add_child(new_icon_dir_node);
-  it_icon->sort_by_id();
 }
 
 // Dialogs


### PR DESCRIPTION
This fixes the ordering of resource node childs, drops `lief.PE.ResourceNode.sort_by_id` (not needed since sorting is done on add), and adds test coverage.

Implemented to this description in [some documentation on Microsoft's site](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#resource-directory-entries) (emphasis on the relevant portion):

> The directory entries make up the rows of a table. Each resource directory entry has the following format. Whether the entry is a Name or ID entry is indicated by the resource directory table, which indicates how many Name and ID entries follow it **(remember that all the Name entries precede all the ID entries for the table). All entries for the table are sorted in ascending order: the Name entries by case-sensitive string and the ID entries by numeric value.** Offsets are relative to the address in the IMAGE_DIRECTORY_ENTRY_RESOURCE DataDirectory. See [Peering Inside the PE: A Tour of the Win32 Portable Executable File Format](https://docs.microsoft.com/en-us/previous-versions/ms809762(v=msdn.10)#pe-file-resources) for more information.