### PR TITLE
Add Python 3.11 b3 to Win64 build

### DIFF
--- a/.github/workflows/windows-x64-all.yml
+++ b/.github/workflows/windows-x64-all.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11.0-beta.3']
       fail-fast: false
     env:
       SCCACHE_CACHE_SIZE: 2G


### PR DESCRIPTION
I'm putting Py311 support on windows 64 only as I'm starting to test cx_Freeze on py311 and it would be nice to have LIEF packages to test it too.