### PR TITLE
Increase numberof_sections when adding section to Mach-O segment

### DIFF
--- a/src/MachO/SegmentCommand.cpp
+++ b/src/MachO/SegmentCommand.cpp
@@ -259,6 +259,7 @@ Section& SegmentCommand::add_section(const Section& section) {
 
   file_size(data_.size());
   sections_.push_back(std::move(new_section));
+  numberof_sections(numberof_sections() + 1);
   return *sections_.back();
 }
 

--- a/tests/macho/test_generic.py
+++ b/tests/macho/test_generic.py
@@ -220,3 +220,25 @@ def test_get_section():
     sample = get_sample("MachO/MachO64_x86-64_binary_large-bss.bin")
     macho = lief.parse(sample)
     assert macho.get_section("__DATA_CONST", "__got") is not None
+
+
+def test_segment_add_section():
+    binary = lief.parse(get_sample('MachO/MachO64_x86-64_binary_safaridriver.bin'))
+
+    section = lief.MachO.Section("__bar", [1, 2, 3])
+
+    existing_segment = binary.get_segment("__TEXT")
+    new_segment = lief.MachO.SegmentCommand("__FOO")
+
+    for segment in (existing_segment, new_segment):
+        assert not segment.has_section(section.name)
+        assert not segment.has(section)
+        assert segment.numberof_sections == len(segment.sections)
+
+        numberof_sections = segment.numberof_sections
+
+        section = segment.add_section(section)
+        assert segment.numberof_sections == numberof_sections + 1
+        assert segment.has_section(section.name)
+        assert segment.has(section)
+        assert section in segment.sections


### PR DESCRIPTION
`lief.MachO.Binary.remove_section` decrements a segment's `numberof_sections` but `lief.MachO.SegmentCommand.add_section` was not incrementing it, which could lead to warnings about mismatch.