### PR TITLE
Improve Mach-O handling of page size

### DIFF
--- a/api/python/MachO/objects/pyBinary.cpp
+++ b/api/python/MachO/objects/pyBinary.cpp
@@ -610,6 +610,10 @@ void create<Binary>(py::module& m) {
         "address"_a, "name"_a,
         py::return_value_policy::reference)
 
+    .def_property_readonly("page_size",
+        &Binary::page_size,
+        "Return the binary's page size")
+
     .def("__getitem__",
         static_cast<LoadCommand* (Binary::*)(LOAD_COMMAND_TYPES)>(&Binary::operator[]),
         "",

--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -47,6 +47,8 @@ Changelog
 
       sec = bin.remove_section("__DATA", "__objc_metadata")
 
+  * Add :attr:`lief.MachO.Binary.page_size`
+
 :PE:
 
   * Remove :meth:`lief.PE.ResourceNode.sort_by_id`

--- a/include/LIEF/MachO/Binary.hpp
+++ b/include/LIEF/MachO/Binary.hpp
@@ -655,7 +655,7 @@ class LIEF_API Binary : public LIEF::Binary  {
     return in_memory_base_addr_;
   }
 
-  uint32_t get_segment_alignment() const;
+  uint32_t page_size() const;
 
   private:
   //! Default constructor

--- a/src/MachO/Builder.tcc
+++ b/src/MachO/Builder.tcc
@@ -132,7 +132,7 @@ ok_error_t Builder::build_segments() {
     std::copy(seg_name.c_str(), seg_name.c_str() + segname_length,
               std::begin(segment_header.segname));
     if (LinkEdit::segmentof(segment) && config_.linkedit) {
-      segment_header.vmsize   = static_cast<uint__>(align(linkedit_.size(), binary->get_segment_alignment()));
+      segment_header.vmsize   = static_cast<uint__>(align(linkedit_.size(), binary->page_size()));
       segment_header.filesize = static_cast<uint__>(linkedit_.size());
     } else {
       segment_header.vmsize = static_cast<uint__>(segment.virtual_size());

--- a/tests/macho/test_builder.py
+++ b/tests/macho/test_builder.py
@@ -164,6 +164,8 @@ def test_add_section_id(tmp_path):
         section = lief.MachO.Section(f"__lief_{i}", [0x90] * 0x100)
         original.add_section(section)
 
+    assert original.virtual_size % original.page_size == 0
+
     original.write(output)
     new = lief.parse(output)
 
@@ -182,6 +184,7 @@ def test_add_section_ssh(tmp_path):
     bin_path = pathlib.Path(get_sample("MachO/MachO64_x86-64_binary_sshd.bin"))
     original = lief.parse(bin_path.as_posix())
     output = f"{tmp_path}/test_add_section_sshd.sshd.bin"
+    page_size = original.page_size
 
     # Add 3 section into __TEXT
     __text = original.get_segment("__TEXT")
@@ -189,6 +192,9 @@ def test_add_section_ssh(tmp_path):
         section = lief.MachO.Section(f"__text_{i}")
         section.content = [0xC3] * 0x100
         original.add_section(__text, section)
+
+    assert original.virtual_size % page_size == 0
+    assert __text.virtual_size % page_size == 0
 
     original.remove_signature()
     original.write(output)
@@ -543,9 +549,4 @@ def test_issue_726(tmp_path):
         new = lief.parse(output)
 
         for parsed in (original, new):
-            if parsed.header.cpu_type == lief.MachO.CPU_TYPES.x86_64:
-                alignment = 0x1000
-            elif original.header.cpu_type == lief.MachO.CPU_TYPES.ARM64:
-                alignment = 0x4000
-
-            assert parsed.get_segment("__LINKEDIT").virtual_size % alignment == 0
+            assert parsed.get_segment("__LINKEDIT").virtual_size % parsed.page_size == 0

--- a/tests/macho/test_generic.py
+++ b/tests/macho/test_generic.py
@@ -252,11 +252,6 @@ def test_issue_728():
     segment.add_section(lief.MachO.Section("__bar", [1, 2, 3]))
 
     for parsed in (x86_64_binary, arm64_binary):
-        if parsed.header.cpu_type == lief.MachO.CPU_TYPES.x86_64:
-            expected_virtual_size = 0x1000
-        elif parsed.header.cpu_type == lief.MachO.CPU_TYPES.ARM64:
-            expected_virtual_size = 0x4000
-
         new_segment = parsed.add(segment)
-        assert new_segment.virtual_size == expected_virtual_size
+        assert new_segment.virtual_size == parsed.page_size
 


### PR DESCRIPTION
Follow-up to #727 to expose `page_size` in the Python API and ensure the correct page size is used according to the binary, not the platform.