### PR TITLE
Fix #735: Make LIEF::DEX::Class copyable

### DIFF
--- a/include/LIEF/DEX/Class.hpp
+++ b/include/LIEF/DEX/Class.hpp
@@ -56,8 +56,8 @@ class LIEF_API Class : public Object {
   static std::string fullname_normalized(const std::string& pkg, const std::string& cls_name);
 
   Class();
-  Class(const Class&) = delete;
-  Class& operator=(const Class&) = delete;
+  Class(const Class&) = default;
+  Class& operator=(const Class&) = default;
 
   Class(std::string fullname, uint32_t access_flags = ACCESS_FLAGS::ACC_UNKNOWN,
         Class* parent = nullptr, std::string source_filename = "");


### PR DESCRIPTION
Bringing back LIEF::DEX::Class copy constructor and assignment operator fixes #735.