### PR TITLE
Fix return_type_ string while printing a DEX method

### DIFF
--- a/src/DEX/Method.cpp
+++ b/src/DEX/Method.cpp
@@ -156,9 +156,10 @@ std::ostream& operator<<(std::ostream& os, const Method& method) {
   if (!flags_str.empty()) {
     os << flags_str << " ";
   }
-  os << proto->return_type()
-     << " "
-     << pretty_cls_name << "->" << method.name();
+  if (const auto* t = proto->return_type()) {
+    os << *t << " ";
+  }
+  os << pretty_cls_name << "->" << method.name();
 
   os << "(";
   for (size_t i = 0; i < ps.size(); ++i) {


### PR DESCRIPTION
When I wanted to print a `LIEF::DEX::Method` object I noticed that an address was shown instead of the method return type string, this is because the return value of `proto->return_type()` isn't dereferenced. I believe this is the right way to fix this.