### PR TITLE
Correction of an ambiguous symbol in the binary API

### DIFF
--- a/include/LIEF/Abstract/Binary.hpp
+++ b/include/LIEF/Abstract/Binary.hpp
@@ -182,7 +182,7 @@ class LIEF_API Binary : public Object {
   virtual uint64_t imagebase() const = 0;
 
   //! Constructor functions that are called prior any other functions
-  virtual LIEF::Binary::functions_t ctor_functions() const = 0;
+  virtual functions_t ctor_functions() const = 0;
 
   //! Convert the given offset into a virtual address.
   //!


### PR DESCRIPTION
Although I cannot provide a minimal reproducible example, this PR corrects error `C2872: 'LIEF': ambiguous symbol`  appearing in some very rare scenarios with MSVC.  

```
lief-src\include\LIEF\Abstract\Binary.hpp(185): error C2872: 'LIEF': ambiguous symbol
```

Signed-off-by: William Roy <wroy@proton.me>