### PR TITLE
Only assign a SymbolVersionAux to a SymbolVersion if it does not have one

### DIFF
--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -1526,7 +1526,7 @@ ok_error_t Parser::parse_symbol_version_definition(uint64_t offset, uint32_t nb_
     for (std::unique_ptr<SymbolVersionAux>& sva : svd->symbol_version_aux_) {
       binary_->sizing_info_->verdef += sizeof(Elf_Verdaux);
       for (std::unique_ptr<SymbolVersion>& sv : binary_->symbol_version_table_) {
-        if (svd->ndx() > 1 && (sv->value() & 0x7FFF) == svd->ndx()) {
+        if (svd->ndx() > 1 && (sv->value() & 0x7FFF) == svd->ndx() && !sv->symbol_aux_) {
           sv->symbol_aux_ = sva.get();
         }
       }


### PR DESCRIPTION
This makes sure that whenever we have a SymbolVersionDefinition with multiple
entries only the first entry gets associated to the SymbolVersion.
Subsequent entries represent version predecessors, not the main version of the symbol
definition. See issue https://github.com/lief-project/LIEF/issues/749