### PR TITLE
Add overloads to write output to std::ostream

### DIFF
--- a/api/python/ELF/objects/pyBinary.cpp
+++ b/api/python/ELF/objects/pyBinary.cpp
@@ -500,7 +500,7 @@ void create<Binary>(py::module& m) {
         "permutation"_a)
 
     .def("write",
-        &Binary::write,
+        static_cast<void (Binary::*)(const std::string&)>(&Binary::write),
         "Rebuild the binary and write it in a file",
         "output"_a,
         py::return_value_policy::reference_internal)

--- a/api/python/ELF/objects/pyBuilder.cpp
+++ b/api/python/ELF/objects/pyBuilder.cpp
@@ -68,7 +68,7 @@ void create<Builder>(py::module& m) {
         py::return_value_policy::reference_internal)
 
     .def("write",
-        &Builder::write,
+        static_cast<void (Builder::*)(const std::string&) const>(&Builder::write),
         "Write the build result into the ``output`` file",
         "output"_a)
 

--- a/api/python/MachO/objects/pyBinary.cpp
+++ b/api/python/MachO/objects/pyBinary.cpp
@@ -424,7 +424,7 @@ void create<Binary>(py::module& m) {
         "address"_a)
 
     .def("write",
-        &Binary::write,
+        static_cast<void (Binary::*)(const std::string&)>(&Binary::write),
         "Rebuild the binary and write and write its content if the file given in parameter",
         "output"_a,
         py::return_value_policy::reference_internal)

--- a/api/python/PE/objects/pyBinary.cpp
+++ b/api/python/PE/objects/pyBinary.cpp
@@ -405,7 +405,7 @@ void create<Binary>(py::module& m) {
         "Remove all imported libraries")
 
     .def("write",
-        &Binary::write,
+        static_cast<void (Binary::*)(const std::string&)>(&Binary::write),
         "Build the binary and write the result to the given ``output`` file",
         "output_path"_a)
 

--- a/api/python/PE/objects/pyBuilder.cpp
+++ b/api/python/PE/objects/pyBuilder.cpp
@@ -94,7 +94,7 @@ void create<Builder>(py::module& m) {
         py::return_value_policy::reference)
 
     .def("write",
-        &Builder::write,
+        static_cast<void (Builder::*)(const std::string&) const>(&Builder::write),
         "Write the build result into the ``output`` file",
         "output"_a)
 

--- a/include/LIEF/Abstract/Binary.hpp
+++ b/include/LIEF/Abstract/Binary.hpp
@@ -195,6 +195,7 @@ class LIEF_API Binary : public Object {
 
   //! Build & transform the Binary object representation into a *real* executable
   virtual void write(const std::string& name) = 0;
+  virtual void write(std::ostream& os) = 0;
 
   LIEF_API friend std::ostream& operator<<(std::ostream& os, const Binary& binary);
 

--- a/include/LIEF/ELF/Binary.hpp
+++ b/include/LIEF/ELF/Binary.hpp
@@ -565,6 +565,11 @@ class LIEF_API Binary : public LIEF::Binary {
   //! @param filename Path for the written ELF binary
   void write(const std::string& filename) override;
 
+  //! Reconstruct the binary object and write it in `os` stream
+  //!
+  //! @param Output stream for the written ELF binary
+  void write(std::ostream& os) override;
+
   //! Reconstruct the binary object and return its content as a byte vector
   std::vector<uint8_t> raw();
 

--- a/include/LIEF/ELF/Builder.hpp
+++ b/include/LIEF/ELF/Builder.hpp
@@ -102,6 +102,9 @@ class LIEF_API Builder {
   //! Write the built ELF binary in the ``filename`` given in parameter
   void write(const std::string& filename) const;
 
+  //! Write the built ELF binary in the stream ``os`` given in parameter
+  void write(std::ostream& os) const;
+
   protected:
   template<typename ELF_T>
   ok_error_t build();

--- a/include/LIEF/MachO/Binary.hpp
+++ b/include/LIEF/MachO/Binary.hpp
@@ -1,3 +1,4 @@
+
 /* Copyright 2017 - 2022 R. Thomas
  * Copyright 2017 - 2022 Quarkslab
  *
@@ -225,6 +226,11 @@ class LIEF_API Binary : public LIEF::Binary  {
   //!
   //! @param filename Path to write the reconstructed binary
   void write(const std::string& filename) override;
+
+  //! Reconstruct the binary object and write the result in the given `os` stream
+  //!
+  //! @param os Output stream to write the reconstructed binary
+  void write(std::ostream& os) override;
 
   //! Reconstruct the binary object and return its content as bytes
   std::vector<uint8_t> raw();

--- a/include/LIEF/MachO/Builder.hpp
+++ b/include/LIEF/MachO/Builder.hpp
@@ -73,19 +73,26 @@ class LIEF_API Builder {
   static ok_error_t write(Binary& binary, std::vector<uint8_t>& out);
   static ok_error_t write(Binary& binary, std::vector<uint8_t>& out, config_t config);
 
+  static ok_error_t write(Binary& binary, std::ostream& out);
+  static ok_error_t write(Binary& binary, std::ostream& out, config_t config);
+
   static ok_error_t write(FatBinary& fat, const std::string& filename);
   static ok_error_t write(FatBinary& fat, const std::string& filename, config_t config);
 
   static ok_error_t write(FatBinary& fat, std::vector<uint8_t>& out);
   static ok_error_t write(FatBinary& fat, std::vector<uint8_t>& out, config_t config);
 
+  static ok_error_t write(FatBinary& fat, std::ostream& out);
+  static ok_error_t write(FatBinary& fat, std::ostream& out, config_t config);
+  
   ~Builder();
   private:
   ok_error_t build();
 
   const std::vector<uint8_t>& get_build();
   ok_error_t write(const std::string& filename) const;
-
+  ok_error_t write(std::ostream& os) const;
+  
   Builder(Binary& binary, config_t config);
   Builder(std::vector<Binary*> binaries, config_t config);
 

--- a/include/LIEF/PE/Binary.hpp
+++ b/include/LIEF/PE/Binary.hpp
@@ -448,11 +448,17 @@ class LIEF_API Binary : public LIEF::Binary {
   // @deprecated This function will be removed in a future version of LIEF
   void hook_function(const std::string& library, const std::string& function, uint64_t address);
 
-  //! Reconstruct the binary object and write the raw PE in  `filename`
+  //! Reconstruct the binary object and write the raw PE in `filename`
   //!
   //! Rebuild a PE binary from the current Binary object.
   //! When rebuilding, import table and relocations are not rebuilt.
   void write(const std::string& filename) override;
+
+  //! Reconstruct the binary object and write the raw PE in `os` stream
+  //!
+  //! Rebuild a PE binary from the current Binary object.
+  //! When rebuilding, import table and relocations are not rebuilt.
+  void write(std::ostream& os) override;
 
   void accept(Visitor& visitor) const override;
 

--- a/include/LIEF/PE/Builder.hpp
+++ b/include/LIEF/PE/Builder.hpp
@@ -92,6 +92,9 @@ class LIEF_API Builder {
 
   //! @brief Write the build result into the ``output`` file
   void write(const std::string& filename) const;
+  
+  //! @brief Write the build result into the ``os`` stream
+  void write(std::ostream& os) const;
 
   LIEF_API friend std::ostream& operator<<(std::ostream& os, const Builder& b);
 

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -1700,6 +1700,11 @@ void Binary::write(const std::string& filename) {
   builder.write(filename);
 }
 
+void Binary::write(std::ostream& os) {
+  Builder builder{ *this };
+  builder.build();
+  builder.write(os);
+}
 
 uint64_t Binary::entrypoint() const {
   return header().entrypoint();

--- a/src/ELF/Builder.cpp
+++ b/src/ELF/Builder.cpp
@@ -127,11 +127,14 @@ void Builder::write(const std::string& filename) const {
     LIEF_ERR("Can't open {}!", filename);
     return;
   }
-  std::vector<uint8_t> content;
-  ios_.move(content);
-  output_file.write(reinterpret_cast<const char*>(content.data()), content.size());
+  write(output_file);
 }
 
+void Builder::write(std::ostream& os) const {
+  std::vector<uint8_t> content;
+  ios_.move(content);
+  os.write(reinterpret_cast<const char*>(content.data()), content.size());
+}
 
 uint32_t Builder::sort_dynamic_symbols() {
   const auto it_begin = std::begin(binary_->dynamic_symbols_);

--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -463,6 +463,9 @@ void Binary::write(const std::string& filename) {
   Builder::write(*this, filename);
 }
 
+void Binary::write(std::ostream& os) {
+  Builder::write(*this, os);
+}
 
 const Section* Binary::section_from_offset(uint64_t offset) const {
   const auto it_section = std::find_if(

--- a/src/PE/Binary.cpp
+++ b/src/PE/Binary.cpp
@@ -157,8 +157,10 @@ Binary::Binary(const std::string& name, PE_TYPE type) :
   optional_header().sizeof_image(virtual_size());
 }
 
-void Binary::write(const std::string& filename) {
-  Builder builder{*this};
+template<typename T>
+static void write_impl(Binary& binary, T&& dest)
+{
+  Builder builder{binary};
 
   builder.
     build_imports(false).
@@ -168,7 +170,15 @@ void Binary::write(const std::string& filename) {
     build_resources(true);
 
   builder.build();
-  builder.write(filename);
+  builder.write(dest);
+}
+
+void Binary::write(const std::string& filename) {
+  write_impl(*this, filename);
+}
+
+void Binary::write(std::ostream& os) {
+  write_impl(*this, os);
 }
 
 TLS& Binary::tls() {

--- a/src/PE/Builder.cpp
+++ b/src/PE/Builder.cpp
@@ -86,21 +86,21 @@ Builder& Builder::build_dos_stub(bool flag) {
   return *this;
 }
 
-
 void Builder::write(const std::string& filename) const {
   std::ofstream output_file{filename, std::ios::out | std::ios::binary | std::ios::trunc};
   if (!output_file) {
     LIEF_ERR("Can't write in {}", filename);
     return;
   }
+  write(output_file);
+}
 
+void Builder::write(std::ostream& os) const {
   std::vector<uint8_t> content;
   ios_.get(content);
   std::copy(std::begin(content), std::end(content),
-            std::ostreambuf_iterator<char>(output_file));
-
+            std::ostreambuf_iterator<char>(os));
 }
-
 
 ok_error_t Builder::build() {
   LIEF_DEBUG("Build process started");
@@ -397,7 +397,7 @@ ok_error_t Builder::construct_resources(ResourceNode& node, std::vector<uint8_t>
 ok_error_t Builder::build_overlay() {
 
   const uint64_t last_section_offset = std::accumulate(
-      std::begin(binary_->sections_), std::end(binary_->sections_), 0,
+      std::begin(binary_->sections_), std::end(binary_->sections_), 0u,
       [] (uint64_t offset, const std::unique_ptr<Section>& section) {
         return std::max<uint64_t>(section->offset() + section->size(), offset);
       });


### PR DESCRIPTION
This allows the user to write to anything that inherits from std::ostream. This is also a work-around for Windows as std::string typically holds ascii and not utf8 so using unicode paths is not particular well supported, with this PR the user can now open an fstream with either wstring or u8string (C++20) and simply pass the stream object. This also allows to write to a stream such std::stringstream allowing to work only with memory. 