### PR TITLE
Remove preprocessor macros for mbedtls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,15 +464,6 @@ endif()
 
 target_compile_definitions(LIB_LIEF PUBLIC -D_GLIBCXX_USE_CXX11_ABI=1)
 
-# Enable support for MD2 and MD4 for parsing the Authenticode sigs of older
-# executables. Also, some older signed executables use certs with the
-# SpcSpAgencyInfo Critical Extension, which mbed TLS doesn't support, so set
-# MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION to have it skip this
-# extension.
-add_definitions(-DMBEDTLS_FS_IO -DMBEDTLS_PEM_PARSE_C -DMBEDTLS_BIGNUM_C
-                -DMBEDTLS_X509_CRT_PARSE_C -DMBEDTLS_PEM_WRITE_C
-                -DMBEDTLS_PKCS1_V15 -DMBEDTLS_PKCS1_V21)
-
 # LIEF Sanitizer options
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 set(SANITIZER_FLAGS -fno-omit-frame-pointer -g -O1)


### PR DESCRIPTION
Those configurations are set by the config.h which is generated via mbedtls CMakes configure_files, this eliminates over 700 warnings due to macro redefinition warnings and is now down to 15 warnings. I also enabled GitHub actions on my fork and it all seems to pass, in case there is a specific configuration missing then we'll have to do that via cmake options which will result in the correct config.h.