### PR TITLE
Avoid using -1u constant and fix conflict with max() macro from Windows API

### DIFF
--- a/include/LIEF/DEX/Class.hpp
+++ b/include/LIEF/DEX/Class.hpp
@@ -16,6 +16,8 @@
 #ifndef LIEF_DEX_CLASS_H_
 #define LIEF_DEX_CLASS_H_
 
+#include <climits>
+
 #include "LIEF/visibility.h"
 #include "LIEF/Object.hpp"
 #include "LIEF/iterators.hpp"
@@ -129,7 +131,7 @@ class LIEF_API Class : public Object {
   fields_t    fields_;
   std::string source_filename_;
 
-  uint32_t original_index_ = -1u;
+  uint32_t original_index_ = UINT_MAX;
 };
 
 } // Namespace DEX

--- a/include/LIEF/DEX/Field.hpp
+++ b/include/LIEF/DEX/Field.hpp
@@ -15,6 +15,8 @@
 #ifndef LIEF_DEX_FIELD_H_
 #define LIEF_DEX_FIELD_H_
 
+#include <climits>
+
 #include "LIEF/DEX/enums.hpp"
 
 #include "LIEF/visibility.h"
@@ -84,7 +86,7 @@ class LIEF_API Field : public Object {
   Class* parent_ = nullptr;
   Type* type_ = nullptr;
   uint32_t access_flags_ = 0;
-  uint32_t original_index_ = -1u;
+  uint32_t original_index_ = UINT_MAX;
   bool is_static_ = false;
 };
 

--- a/include/LIEF/DEX/Method.hpp
+++ b/include/LIEF/DEX/Method.hpp
@@ -16,6 +16,7 @@
 #ifndef LIEF_DEX_METHOD_H_
 #define LIEF_DEX_METHOD_H_
 
+#include <climits>
 
 #include "LIEF/visibility.h"
 #include "LIEF/Object.hpp"
@@ -99,7 +100,7 @@ class LIEF_API Method : public Object {
   Class* parent_ = nullptr;
   Prototype* prototype_ = nullptr;
   uint32_t access_flags_ = ACCESS_FLAGS::ACC_UNKNOWN;
-  uint32_t original_index_ = -1u;
+  uint32_t original_index_ = UINT_MAX;
   bool is_virtual_ = false;
 
   uint64_t code_offset_ = 0;

--- a/include/LIEF/MachO/BinaryParser.hpp
+++ b/include/LIEF/MachO/BinaryParser.hpp
@@ -74,10 +74,10 @@ class LIEF_API BinaryParser : public LIEF::Parser {
   friend class MachO::Parser;
 
   //! Maximum number of relocations
-  constexpr static size_t MAX_RELOCATIONS = std::numeric_limits<uint16_t>::max();
+  constexpr static size_t MAX_RELOCATIONS = (std::numeric_limits<uint16_t>::max)();
 
   //! Maximum number of MachO LoadCommand
-  constexpr static size_t MAX_COMMANDS = std::numeric_limits<uint16_t>::max();
+  constexpr static size_t MAX_COMMANDS = (std::numeric_limits<uint16_t>::max)();
 
   public:
   static std::unique_ptr<Binary> parse(const std::string& file);

--- a/include/LIEF/PE/ExportEntry.hpp
+++ b/include/LIEF/PE/ExportEntry.hpp
@@ -70,7 +70,7 @@ class LIEF_API ExportEntry : public LIEF::Symbol {
   }
 
   inline void value(uint64_t value) override {
-    address(value);
+    address(static_cast<uint32_t>(value));
   }
 
   inline void set_forward_info(std::string lib, std::string function)  {

--- a/include/LIEF/PE/resources/ResourceIcon.hpp
+++ b/include/LIEF/PE/resources/ResourceIcon.hpp
@@ -17,6 +17,7 @@
 #define LIEF_PE_RESOURCE_ICON_H_
 #include <iostream>
 #include <sstream>
+#include <climits>
 
 #include "LIEF/visibility.h"
 
@@ -110,7 +111,7 @@ class LIEF_API ResourceIcon : public Object {
   uint8_t              reserved_ = 0;
   uint16_t             planes_ = 0;
   uint16_t             bit_count_ = 0;
-  uint32_t             id_ = -1u;
+  uint32_t             id_ = UINT_MAX;
   RESOURCE_LANGS       lang_ = RESOURCE_LANGS::LANG_NEUTRAL;
   RESOURCE_SUBLANGS    sublang_ = RESOURCE_SUBLANGS::SUBLANG_DEFAULT;
   std::vector<uint8_t> pixels_;

--- a/src/BinaryStream/BinaryStream.cpp
+++ b/src/BinaryStream/BinaryStream.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <algorithm>
 #include <iostream>
+#include <climits>
 
 #define TMPL_DECL(T) template T BinaryStream::swap_endian<T>(T u)
 
@@ -250,7 +251,7 @@ result<std::u16string> BinaryStream::read_u16string(size_t length) const {
 }
 
 result<std::u16string> BinaryStream::peek_u16string(size_t length) const {
-  if (length == static_cast<size_t>(-1u)) {
+  if (length == static_cast<size_t>(SIZE_MAX)) {
     return peek_u16string();
   }
 

--- a/src/DEX/Class.cpp
+++ b/src/DEX/Class.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <utility>
+#include <climits>
 
 #include "LIEF/DEX/Class.hpp"
 #include "LIEF/DEX/hash.hpp"
@@ -30,7 +31,7 @@ Class::Class(std::string  fullname, uint32_t access_flags,
   access_flags_{access_flags},
   parent_{parent},
   source_filename_{std::move(source_filename)},
-  original_index_{-1u}
+  original_index_{UINT_MAX}
 {}
 
 std::string Class::package_normalized(const std::string& pkg) {

--- a/src/DEX/File.cpp
+++ b/src/DEX/File.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <fstream>
+#include <climits>
 #include "logging.hpp"
 #include "LIEF/DEX/File.hpp"
 #include "LIEF/DEX/instructions.hpp"
@@ -88,7 +89,7 @@ std::vector<uint8_t> File::raw(bool deoptimize) const {
     while (inst_ptr < inst_end) {
       uint16_t dex_pc = (inst_ptr - inst_start) / sizeof(uint16_t);
       auto opcode = static_cast<OPCODES>(*inst_ptr);
-      uint32_t value = -1u;
+      uint32_t value = UINT_MAX;
 
       if (meth_info.find(dex_pc) != std::end(meth_info)) {
         value = meth_info[dex_pc];

--- a/src/DEX/instructions.cpp
+++ b/src/DEX/instructions.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <iostream>
 #include <map>
+#include <climits>
 
 namespace LIEF {
 namespace DEX {
@@ -282,7 +283,7 @@ INST_FORMATS inst_format_from_opcode(OPCODES op) {
 
 size_t inst_size_from_format(INST_FORMATS fmt) {
   static const std::map<INST_FORMATS, size_t> size_map {
-    { INST_FORMATS::F_00x,   -1u  },
+    { INST_FORMATS::F_00x,   SIZE_MAX  },
     { INST_FORMATS::F_10x,   2    },
     { INST_FORMATS::F_12x,   2    },
     { INST_FORMATS::F_11n,   2    },
@@ -365,7 +366,7 @@ bool is_switch_array(const uint8_t* ptr, const uint8_t* end) {
 
 size_t switch_array_size(const uint8_t* ptr, const uint8_t* end) {
   if (!is_switch_array(ptr, end)) {
-    return -1u;
+    return SIZE_MAX;
   }
 
   const auto opcode = static_cast<OPCODES>(*ptr);
@@ -401,7 +402,7 @@ size_t switch_array_size(const uint8_t* ptr, const uint8_t* end) {
       }
     default:
       {
-        return -1u;
+        return SIZE_MAX;
       }
   }
 

--- a/src/ELF/Relocation.cpp
+++ b/src/ELF/Relocation.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <iomanip>
+#include <climits>
 
 #include "LIEF/exception.hpp"
 #include "LIEF/ELF/hash.hpp"
@@ -170,7 +171,7 @@ size_t Relocation::size() const {
         const auto it = relocation_x86_64_sizes.find(static_cast<RELOC_x86_64>(type()));
         if (it == std::end(relocation_x86_64_sizes)) {
           LIEF_ERR("{} - {}", to_string(architecture()), to_string(static_cast<RELOC_x86_64>(type())));
-          return -1u;
+          return SIZE_MAX;
         }
         return it->second;
       }
@@ -180,7 +181,7 @@ size_t Relocation::size() const {
         const auto it = relocation_i386_sizes.find(static_cast<RELOC_i386>(type()));
         if (it == std::end(relocation_i386_sizes)) {
           LIEF_ERR("{} - {}", to_string(architecture()), to_string(static_cast<RELOC_i386>(type())));
-          return -1u;
+          return SIZE_MAX;
         }
         return it->second;
       }
@@ -190,7 +191,7 @@ size_t Relocation::size() const {
         const auto it = relocation_ARM_sizes.find(static_cast<RELOC_ARM>(type()));
         if (it == std::end(relocation_ARM_sizes)) {
           LIEF_ERR("{} - {}", to_string(architecture()), to_string(static_cast<RELOC_ARM>(type())));
-          return -1u;
+          return SIZE_MAX;
         }
         return it->second;
       }
@@ -200,7 +201,7 @@ size_t Relocation::size() const {
         const auto it = relocation_AARCH64_sizes.find(static_cast<RELOC_AARCH64>(type()));
         if (it == std::end(relocation_AARCH64_sizes)) {
           LIEF_ERR("{} - {}", to_string(architecture()), to_string(static_cast<RELOC_AARCH64>(type())));
-          return -1u;
+          return SIZE_MAX;
         }
         return it->second;
       }
@@ -210,7 +211,7 @@ size_t Relocation::size() const {
         const auto it = relocation_MIPS_sizes.find(static_cast<RELOC_MIPS>(type()));
         if (it == std::end(relocation_MIPS_sizes)) {
           LIEF_ERR("{} - {}", to_string(architecture()), to_string(static_cast<RELOC_MIPS>(type())));
-          return -1u;
+          return SIZE_MAX;
         }
         return it->second;
       }
@@ -221,7 +222,7 @@ size_t Relocation::size() const {
         const auto it = relocation_PPC_sizes.find(static_cast<RELOC_POWERPC32>(type()));
         if (it == std::end(relocation_PPC_sizes)) {
           LIEF_ERR("{} - {}", to_string(architecture()), to_string(static_cast<RELOC_POWERPC32>(type())));
-          return -1u;
+          return SIZE_MAX;
         }
         return it->second;
       }
@@ -231,7 +232,7 @@ size_t Relocation::size() const {
         const auto it = relocation_PPC64_sizes.find(static_cast<RELOC_POWERPC64>(type()));
         if (it == std::end(relocation_PPC64_sizes)) {
           LIEF_ERR("{} - {}", to_string(architecture()), to_string(static_cast<RELOC_POWERPC64>(type())));
-          return -1u;
+          return SIZE_MAX;
         }
         return it->second;
       }
@@ -239,7 +240,7 @@ size_t Relocation::size() const {
     default:
       {
         LIEF_ERR("Architecture {} not implemented", to_string(architecture()));
-        return -1u;
+        return SIZE_MAX;
       }
   }
 

--- a/src/OAT/Class.cpp
+++ b/src/OAT/Class.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <utility>
+#include <climits>
 
 #include "LIEF/OAT/Class.hpp"
 #include "LIEF/OAT/Method.hpp"
@@ -91,7 +92,7 @@ size_t Class::index() const {
   if (has_dex_class()) {
     return dex_class()->index();
   }
-  return -1ull;
+  return SIZE_MAX;
 }
 
 const std::vector<uint32_t>& Class::bitmap() const {
@@ -148,7 +149,7 @@ bool Class::is_quickened(uint32_t relative_index) const {
 
 uint32_t Class::method_offsets_index(const DEX::Method& m) const {
   if (!has_dex_class()) {
-    return -1u;
+    return UINT_MAX;
   }
   const DEX::Class& cls = *dex_class();
 
@@ -160,7 +161,7 @@ uint32_t Class::method_offsets_index(const DEX::Method& m) const {
 
   if (it_method_index == std::end(methods)) {
     LIEF_ERR("Can't find '{}' in {}", m.name(), cls.fullname());
-    return -1u;
+    return UINT_MAX;
   }
 
   uint32_t relative_index = std::distance(std::begin(methods), it_method_index);
@@ -170,7 +171,7 @@ uint32_t Class::method_offsets_index(const DEX::Method& m) const {
 uint32_t Class::method_offsets_index(uint32_t relative_index) const {
 
   if (!is_quickened(relative_index) || type() == OAT_CLASS_TYPES::OAT_CLASS_NONE_COMPILED) {
-    return -1u;
+    return UINT_MAX;
   }
 
   if (type() == OAT_CLASS_TYPES::OAT_CLASS_ALL_COMPILED) {
@@ -192,12 +193,12 @@ uint32_t Class::method_offsets_index(uint32_t relative_index) const {
     return count;
   }
 
-  return -1u;
+  return UINT_MAX;
 }
 
 uint32_t Class::relative_index(const DEX::Method& m) const {
   if (!has_dex_class()) {
-    return -1u;
+    return UINT_MAX;
   }
   const DEX::Class& cls = *dex_class();
 
@@ -209,7 +210,7 @@ uint32_t Class::relative_index(const DEX::Method& m) const {
 
   if (it_method_index == std::end(methods)) {
     LIEF_ERR("Can't find '{}' in {}", m.name(), cls.fullname());
-    return -1u;
+    return UINT_MAX;
   }
 
   return std::distance(std::begin(methods), it_method_index);
@@ -217,7 +218,7 @@ uint32_t Class::relative_index(const DEX::Method& m) const {
 
 uint32_t Class::relative_index(uint32_t method_absolute_index) const {
   if (!has_dex_class()) {
-    return -1u;
+    return UINT_MAX;
   }
   const DEX::Class& cls = *dex_class();
 
@@ -229,7 +230,7 @@ uint32_t Class::relative_index(uint32_t method_absolute_index) const {
 
   if (it_method_index == std::end(methods)) {
     LIEF_ERR("Can't find find method with index {:d} in {}", method_absolute_index, cls.fullname());
-    return -1u;
+    return UINT_MAX;
   }
 
   return std::distance(std::begin(methods), it_method_index);

--- a/src/PE/Parser.cpp
+++ b/src/PE/Parser.cpp
@@ -220,7 +220,7 @@ ok_error_t Parser::parse_sections() {
   const uint32_t opt_header_off  = pe_header_off + sizeof(details::pe_header);
   const uint32_t sections_offset = opt_header_off + binary_->header().sizeof_optional_header();
 
-  uint32_t first_section_offset = -1u;
+  uint32_t first_section_offset = UINT_MAX;
 
   uint32_t numberof_sections = binary_->header().numberof_sections();
   if (numberof_sections > NB_MAX_SECTIONS) {


### PR DESCRIPTION
This commit introduces one improvement to make easy to build softwares that depends on `LIEF` when treating warnings as error and also a fix to a conflict between `std::numeric_limits::max()` and `max()` function from `Windows API`. If a `LIEF`'s client includes parts of `Windows` headers that will hit on `max` macro and after including some `LIEF` headers, some compilation errors complaining about this conflict will show up.

The improvement related to silent up the `MSVC` "unary minus operator applied to unsigned type, result still unsigned" is about stop using the hardcoded `-1u` and start using the suitable constants defined in `climits` (i.e.: `limits.h`). Being `UINT_MAX` for `uint32_t` and `SIZE_MAX` for `size_t`.

The fix related to the compilation error produced by the conflict with `max()` macro from `Windows API` was merely wrap
`std::numeric_limits::max()` statement with `(...)`.

I hope that helps!