### PR TITLE
Fix compiler warning in `LIEF::BinaryStream::peek_u16string()`

### DIFF
--- a/src/BinaryStream/BinaryStream.cpp
+++ b/src/BinaryStream/BinaryStream.cpp
@@ -229,7 +229,6 @@ result<std::u16string> BinaryStream::peek_u16string() const {
     return u16_str;
   }
 
-  size_t count = 0;
   do {
     c = peek<char16_t>(off);
     if (!c) {
@@ -237,7 +236,6 @@ result<std::u16string> BinaryStream::peek_u16string() const {
     }
     off += sizeof(char16_t);
     u16_str.push_back(*c);
-    ++count;
   } while (c && *c != 0 && off < size());
   u16_str.back() = '\0';
   return u16_str.c_str();


### PR DESCRIPTION
This change fixes this compiler warning:

```sh
[218/228] Building CXX object vendor/lief/CMakeFiles/LIB_LIEF.dir/src/BinaryStream/BinaryStream.cpp.o
/Users/raisinten/Desktop/git/postject/vendor/lief/src/BinaryStream/BinaryStream.cpp:232:10: warning: variable 'count' set but not used [-Wunused-but-set-variable]
  size_t count = 0;
         ^
1 warning generated.
```

by removing all uses of count because it is unused.

Signed-off-by: Darshan Sen <raisinten@gmail.com>