### PR TITLE
Bugfix for ImportEntry to accept PE_TYPE

### DIFF
--- a/api/python/PE/objects/pyImportEntry.cpp
+++ b/api/python/PE/objects/pyImportEntry.cpp
@@ -51,6 +51,14 @@ void create<ImportEntry>(py::module& m) {
         "Constructor from a :attr:`~lief.PE.ImportEntry.data` and an optionally :attr:`~lief.PE.ImportEntry.name`",
         "data"_a, "name"_a = "")
 
+    .def(py::init<uint64_t, PE_TYPE, const std::string&>(),
+        "Constructor from a :attr:`~lief.PE.ImportEntry.data`, a :attr:`~lief.PE.ImportEntry.type` and an optional :attr:`~lief.PE.ImportEntry.name`",
+        "data"_a, "type"_a, "name"_a = "")
+
+    .def(py::init<const std::string&, PE_TYPE>(),
+        "Constructor from a :attr:`~lief.PE.ImportEntry.name`, and a :attr:`~lief.PE.ImportEntry.type`",
+        "name"_a, "type"_a)
+
     .def_property("name",
         [] (const ImportEntry& obj) {
           return safe_string_converter(obj.name());

--- a/include/LIEF/PE/ImportEntry.hpp
+++ b/include/LIEF/PE/ImportEntry.hpp
@@ -40,7 +40,9 @@ class LIEF_API ImportEntry : public LIEF::Symbol {
   public:
   ImportEntry();
   ImportEntry(uint64_t data, const std::string& name = "");
+  ImportEntry(uint64_t data, PE_TYPE type, const std::string& name);
   ImportEntry(const std::string& name);
+  ImportEntry(const std::string& name, PE_TYPE type);
   ImportEntry(const ImportEntry&);
   ImportEntry& operator=(const ImportEntry&);
   virtual ~ImportEntry();

--- a/src/PE/ImportEntry.cpp
+++ b/src/PE/ImportEntry.cpp
@@ -37,9 +37,19 @@ ImportEntry::ImportEntry(uint64_t data, const std::string& name) :
   name_ = name;
 }
 
+ImportEntry::ImportEntry(uint64_t data, PE_TYPE type, const std::string& name) :
+  data_{data},
+  type_{type}
+{
+  name_ = name;
+}
 
 ImportEntry::ImportEntry(const std::string& name) :
   ImportEntry{0, name}
+{}
+
+ImportEntry::ImportEntry(const std::string& name, PE_TYPE type) :
+  ImportEntry{0, type, name}
 {}
 
 bool ImportEntry::is_ordinal() const {

--- a/tests/pe/test_ordinals.py
+++ b/tests/pe/test_ordinals.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import lief
+import pytest
+
+from utils import get_sample
+
+
+@pytest.mark.parametrize("test_exe", [
+    "PE/PE32_x86_binary_HelloWorld.exe",
+    "PE/PE64_x86-64_binary_HelloWorld.exe",
+])
+def test_add_ordinal(tmp_path, test_exe):
+    lib_name = "LIEF_UNITTEST.dll"
+    ordinal_val = 42
+    orig_path = get_sample(test_exe)
+    new_path = tmp_path / "add_ordinal.exe"
+
+    binary = lief.parse(orig_path)
+    pe_type = binary.optional_header.magic
+    ordinal_mask = 0x1 << 63  # PE32+, aka 64-bit PE
+    if pe_type == lief.PE.PE_TYPE.PE32:
+        ordinal_mask = 0x1 << 31  # PE32, aka 32-bit PE
+    test_lib = binary.add_library(lib_name)
+    ord_data = ordinal_val | ordinal_mask
+    new_entry = lief.PE.ImportEntry(data=ord_data, type=pe_type)
+    test_lib.add_entry(entry=new_entry)
+
+    builder = lief.PE.Builder(binary)
+    builder.build_imports(True).patch_imports(True)
+    builder.build()
+    builder.write(str(new_path))
+
+    new_binary = lief.parse(str(new_path))
+    assert new_binary.has_import(lib_name)
+    new_lib = binary.get_import(lib_name)
+    first_ord = next(iter([e for e in new_lib.entries if e.is_ordinal]))
+    assert first_ord is not None
+    assert first_ord.ordinal == ordinal_val


### PR DESCRIPTION
In the Python bindings, a new instance of ImportEntry has it's type hard-coded to PE_TYPE::PE32, with no way to change the type once created.

This prevents adding new ordinal imports to PE32+, aka 64-bit, binaries.

The fix is to allow ImportEntry to also accept PE_TYPE. In addition, the unittest also documents how to add an ordinal using LIEF.

* Update ImportEntry to accept PE_TYPE
* Update python bindings for ImportEntry
* Add unittest for ImportEntry and ordinals