### PR TITLE
Use Segment::file_offset() instead of Binary::virtual_address_to_offset() for parsing note segment

### DIFF
--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -278,12 +278,7 @@ ok_error_t Parser::parse_binary() {
       continue;
     }
 
-    const uint64_t va = segment.virtual_address();
-    if (auto res = binary_->virtual_address_to_offset(va)) {
-      parse_notes(*res, segment.physical_size());
-    } else {
-      LIEF_WARN("Can't convert PT_NOTE.virtual_address into an offset (0x{:x})", va);
-    }
+    parse_notes(segment.file_offset(), segment.physical_size());
   }
 
   // Parse Note Sections


### PR DESCRIPTION

fix #808