### PR TITLE
Fix name lookup issue on older gcc

### DIFF
--- a/src/PE/Binary.cpp
+++ b/src/PE/Binary.cpp
@@ -1745,7 +1745,7 @@ std::ostream& Binary::print(std::ostream& os) const {
   if (has_debug()) {
     os << "Debug" << std::endl;
     os << "=====" << std::endl;
-    for (const Debug& debug : debug()) {
+    for (const Debug& debug : this->debug()) {
       os << debug << std::endl;
     }
     os << std::endl;


### PR DESCRIPTION
I am trying to update the LIEF conan package.
https://github.com/conan-io/conan-center-index/pull/13660

Older gcc (e.g. gcc 5) seems to have some compile errors due to the name lookup logic.
I have created a PR that adds `this->` as a prefix.
If it could be merged, it would be helpful for future LIEF packaging.
