### PR TITLE
Fixes to tutorials

### DIFF
--- a/doc/sphinx/tutorials/03_elf_change_symbols.rst
+++ b/doc/sphinx/tutorials/03_elf_change_symbols.rst
@@ -35,7 +35,7 @@ Imported and exported functions are abstracted by LIEF thus you can iterate over
 
 
 When analyzing a binary, imported function names are very helpful for the reverse engineering. One solution is to link statically the binary and the library.
-Another solution is to blow mind the reverser's mind by swapping these symbols.
+Another solution is to blow the reverser's mind by swapping these symbols.
 
 Take a look at the following code:
 

--- a/doc/sphinx/tutorials/03_elf_change_symbols.rst
+++ b/doc/sphinx/tutorials/03_elf_change_symbols.rst
@@ -35,7 +35,7 @@ Imported and exported functions are abstracted by LIEF thus you can iterate over
 
 
 When analyzing a binary, imported function names are very helpful for the reverse engineering. One solution is to link statically the binary and the library.
-Another solution is to blow the reverser's mind by swapping these symbols.
+Another solution is to blow the reverser's mind by swapping these symbols. This is what we're going to do.
 
 Take a look at the following code:
 

--- a/doc/sphinx/tutorials/04_elf_hooking.rst
+++ b/doc/sphinx/tutorials/04_elf_hooking.rst
@@ -11,7 +11,7 @@ By Romain Thomas - `@rh0main <https://twitter.com/rh0main>`_
 
 In the previous tutorial we saw how to swap symbols names from a shared library, we will now see the mechanism to hook a function in a shared library.
 
-The targeted library is the standard math library (``libm.so``) and we will insert a hook on the ``exp`` function so that :math:`exp(x) = x + 1`. The source code of the sample that uses this function is given in the following listing:
+The targeted library is the standard math library (``libm.so``) and we will insert a hook on the ``exp`` function so that :math:`\exp(x) = x + 1`. The source code of the sample that uses this function is given in the following listing:
 
 .. code-block:: cpp
 

--- a/doc/sphinx/tutorials/04_elf_hooking.rst
+++ b/doc/sphinx/tutorials/04_elf_hooking.rst
@@ -80,7 +80,7 @@ To test the patched library:
 
   $ ./do_math.bin 1
   exp(1) = 2.718282
-  LD_LIBRARY_PATH=. ./do_math.bin 1
+  $ LD_LIBRARY_PATH=. ./do_math.bin 1
   exp(1) = 2.000000
 
 

--- a/doc/sphinx/tutorials/04_elf_hooking.rst
+++ b/doc/sphinx/tutorials/04_elf_hooking.rst
@@ -3,7 +3,7 @@
 
 The objective of this tutorial is to hook a library function
 
-Scripts and materials are available here: `materials <https://github.com/lief-project/tutorials/tree/master/03_ELF_hooking>`_
+Scripts and materials are available here: `materials <https://github.com/lief-project/tutorials/tree/master/04_ELF_hooking>`_
 
 By Romain Thomas - `@rh0main <https://twitter.com/rh0main>`_
 


### PR DESCRIPTION
Hi, I was following along the tutorials and noticed that the tutorial 04 is a bit incomplete. This PR updates the tutorial so that it contains all of the the example Python code [here](https://github.com/lief-project/tutorials/tree/master/04_ELF_hooking) (although note that the hooked function in the tutorial is `exp`, while in the example script it is `cos`). I also updated the address calculation logic in the tutorial to match the example, but I haven't checked if it's correct.

I also fixed a broken link and some small typos.