### PR TITLE
Fix ambiguous name error with `using namespace std;`

### DIFF
--- a/include/LIEF/Object.hpp
+++ b/include/LIEF/Object.hpp
@@ -19,18 +19,19 @@
 #include "LIEF/Visitor.hpp"
 #include "LIEF/visibility.h"
 
-template< class T >
-using add_pointer_t = typename std::add_pointer<T>::type;
-
-template< class T >
-using decay_t = typename std::decay<T>::type;
-
-template< class T >
-using add_const_t = typename std::add_const<T>::type;
-
 namespace LIEF {
 
 class LIEF_API Object {
+
+  template<class T>
+  using add_pointer_t = typename std::add_pointer<T>::type;
+
+  template<class T>
+  using decay_t = typename std::decay<T>::type;
+
+  template<class T>
+  using add_const_t = typename std::add_const<T>::type;
+
   public:
   template<class T>
   using output_t = add_pointer_t<decay_t<T>>;


### PR DESCRIPTION
When including LIEF after a `using namespace std` you get errors that those helper types are conflicting with the ones in `std`. We moved them inside the `Object` to prevent this error.

Related: https://github.com/lifting-bits/sleigh/pull/143