### PR TITLE
Avoid memory leak for Dynamic entries in C API

### DIFF
--- a/api/c/ELF/DynamicEntry.cpp
+++ b/api/c/ELF/DynamicEntry.cpp
@@ -208,14 +208,24 @@ void destroy_dynamic_entries(Elf_Binary_t* c_binary) {
       case DYNAMIC_TAGS::DT_FINI_ARRAY:
       case DYNAMIC_TAGS::DT_PREINIT_ARRAY:
         {
-          free(reinterpret_cast<Elf_DynamicEntry_Array_t*>(dynamic_entries[idx]));
+          Elf_DynamicEntry_Array_t* entry_array=reinterpret_cast<Elf_DynamicEntry_Array_t*>(dynamic_entries[idx]);
+          free(entry_array->array);
+          free(entry_array);
           break;
         }
 
       case DYNAMIC_TAGS::DT_FLAGS:
+        {
+          Elf_DynamicEntry_Flags_t* entry_flags=reinterpret_cast<Elf_DynamicEntry_Flags_t*>(dynamic_entries[idx]);
+          free(entry_flags->flags);
+          free(entry_flags);
+          break;
+        }
       case DYNAMIC_TAGS::DT_FLAGS_1:
         {
-          free(reinterpret_cast<Elf_DynamicEntry_Flags_t*>(dynamic_entries[idx]));
+          Elf_DynamicEntry_Flags_t* entry_flags=reinterpret_cast<Elf_DynamicEntry_Flags_t*>(dynamic_entries[idx]);
+          free(entry_flags->flags_1);
+          free(entry_flags);
           break;
         }
 


### PR DESCRIPTION
The array and flag fields of the corresponding dynamic entries need to be freed as well.