### PR TITLE
Avoid null pointer dereference caused by unexpected segment in c api

### DIFF
--- a/api/c/ELF/Segment.cpp
+++ b/api/c/ELF/Segment.cpp
@@ -28,10 +28,12 @@ void init_c_segments(Elf_Binary_t* c_binary, Binary* binary) {
 
     span<const uint8_t> segment_content = segment.content();
     auto* content = static_cast<uint8_t*>(malloc(segment_content.size() * sizeof(uint8_t)));
-    std::copy(
+    if (content) {
+      std::copy(
         std::begin(segment_content),
         std::end(segment_content),
         content);
+    }
 
     c_binary->segments[i] = static_cast<Elf_Segment_t*>(malloc(sizeof(Elf_Segment_t)));
     c_binary->segments[i]->type            = static_cast<enum LIEF_ELF_SEGMENT_TYPES>(segment.type());

--- a/examples/c/elf_reader.c
+++ b/examples/c/elf_reader.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
         segment->size,
         segment->alignment
         );
-    if (segment->size > 3) {
+    if (segment->size > 3 && segment->content != NULL) {
       fprintf(stdout, "content[0..3]: %02x %02x %02x\n",
           segment->content[0], segment->content[1], segment->content[2]);
     }


### PR DESCRIPTION
Fix #845 