### PR TITLE
ELF: fix assertion failure in `Binary::strings()`

### DIFF
--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -536,7 +536,7 @@ Binary::string_list_t Binary::strings(size_t min_size) const {
   current.reserve(100);
 
   for (size_t i = 0; i < data.size(); ++i) {
-    char c = static_cast<char>(data[i]);
+    uint8_t c = data[i];
 
     // Terminator
     if (c == '\0') {
@@ -555,7 +555,7 @@ Binary::string_list_t Binary::strings(size_t min_size) const {
       continue;
     }
 
-    current.push_back(c);
+    current.push_back(static_cast<char>(c));
   }
 
 


### PR DESCRIPTION
`std::isprint()` will assert (at least, on Windows) if the integer checked is < 0. Have it check the uint8_t value instead.