### PR TITLE
Fix include when use LIEF_ENABLE_JSON=OFF

### DIFF
--- a/src/ELF/json_api.cpp
+++ b/src/ELF/json_api.cpp
@@ -17,6 +17,9 @@
 
 #if LIEF_JSON_SUPPORT
 #include "ELF/json_internal.hpp"
+#else /* JSON not enabled */
+#include "logging.hpp"
+#include "LIEF/json.hpp"
 #endif
 
 namespace LIEF {

--- a/src/json_api.cpp
+++ b/src/json_api.cpp
@@ -45,6 +45,8 @@
   #if defined(LIEF_VDEX_SUPPORT)
     #include "VDEX/json_internal.hpp"
   #endif
+#else /* JSON not enabled */
+  #include "logging.hpp"
 #endif // LIEF_JSON_SUPPORT
 
 namespace LIEF {


### PR DESCRIPTION
Fix compilation error when build ELF support with LIEF_ENABLE_JSON=OFF :
```
[32:18:2/51]Building CXX object _deps/lieflib-build/CMakeFiles/LIB_LIEF.dir/src/json_api.cpp.o
FAILED: _deps/lieflib-build/CMakeFiles/LIB_LIEF.dir/src/json_api.cpp.o 
/build/_deps/lieflib-src/src/json_api.cpp:123:3: error: use of undeclared identifier 'LIEF_WARN'
  LIEF_WARN("JSON support is not enabled");
  ^
1 error generated.
[6:18:28/51]Building CXX object _deps/lieflib-build/CMakeFiles/LIB_LIEF.dir/src/ELF/json_api.cpp.o
FAILED: _deps/lieflib-build/CMakeFiles/LIB_LIEF.dir/src/ELF/json_api.cpp.o 
/build/_deps/lieflib-src/src/ELF/json_api.cpp:25:1: error: use of undeclared identifier 'std'
std::string to_json(const Object& v) {
^
/build/_deps/lieflib-src/src/ELF/json_api.cpp:25:27: error: unknown type name 'Object'
std::string to_json(const Object& v) {
                          ^
/build/_deps/lieflib-src/src/ELF/json_api.cpp:31:3: error: use of undeclared identifier 'LIEF_WARN'
  LIEF_WARN("JSON support is not enabled");
  ^
/build/_deps/lieflib-src/src/ELF/json_api.cpp:32:10: error: cannot initialize return object of type 'int' with an lvalue of type 'const char[1]'
  return "";
         ^~
4 errors generated.
```


This commit has only be tested with ELF support and only the C++ API enable, others header may be broken.