### PR TITLE
feat(macho): allow to create DynamicSymbolCommand in Python

### DIFF
--- a/api/python/src/MachO/objects/pyDynamicSymbolCommand.cpp
+++ b/api/python/src/MachO/objects/pyDynamicSymbolCommand.cpp
@@ -45,7 +45,8 @@ void create<DynamicSymbolCommand>(py::module& m) {
       This command completes the LC_SYMTAB (SymbolCommand) to provide
       a better granularity over the symbols layout.
       )delim")
-    .def(py::init(&DynamicSymbolCommand::createForPython))
+
+    .def(py::init<>())
 
     .def_property("idx_local_symbol",
       static_cast<getter_t<uint32_t>>(&DynamicSymbolCommand::idx_local_symbol),

--- a/api/python/src/MachO/objects/pyDynamicSymbolCommand.cpp
+++ b/api/python/src/MachO/objects/pyDynamicSymbolCommand.cpp
@@ -45,6 +45,7 @@ void create<DynamicSymbolCommand>(py::module& m) {
       This command completes the LC_SYMTAB (SymbolCommand) to provide
       a better granularity over the symbols layout.
       )delim")
+    .def(py::init(&DynamicSymbolCommand::createForPython))
 
     .def_property("idx_local_symbol",
       static_cast<getter_t<uint32_t>>(&DynamicSymbolCommand::idx_local_symbol),

--- a/include/LIEF/MachO/DynamicSymbolCommand.hpp
+++ b/include/LIEF/MachO/DynamicSymbolCommand.hpp
@@ -48,8 +48,6 @@ class LIEF_API DynamicSymbolCommand : public LoadCommand {
 
   DynamicSymbolCommand(const details::dysymtab_command& cmd);
 
-  static DynamicSymbolCommand createForPython();
-
   DynamicSymbolCommand& operator=(const DynamicSymbolCommand& copy);
   DynamicSymbolCommand(const DynamicSymbolCommand& copy);
 
@@ -180,32 +178,32 @@ class LIEF_API DynamicSymbolCommand : public LoadCommand {
   static bool classof(const LoadCommand* cmd);
 
   private:
-  uint32_t idx_local_symbol_;
-  uint32_t nb_local_symbols_;
+  uint32_t idx_local_symbol_ = 0;
+  uint32_t nb_local_symbols_ = 0;
 
-  uint32_t idx_external_define_symbol_;
-  uint32_t nb_external_define_symbols_;
+  uint32_t idx_external_define_symbol_ = 0;
+  uint32_t nb_external_define_symbols_ = 0;
 
-  uint32_t idx_undefined_symbol_;
-  uint32_t nb_undefined_symbols_;
+  uint32_t idx_undefined_symbol_ = 0;
+  uint32_t nb_undefined_symbols_ = 0;
 
-  uint32_t toc_offset_;
-  uint32_t nb_toc_;
+  uint32_t toc_offset_ = 0;
+  uint32_t nb_toc_ = 0;
 
-  uint32_t module_table_offset_;
-  uint32_t nb_module_table_;
+  uint32_t module_table_offset_ = 0;
+  uint32_t nb_module_table_ = 0;
 
-  uint32_t external_reference_symbol_offset_;
-  uint32_t nb_external_reference_symbols_;
+  uint32_t external_reference_symbol_offset_ = 0;
+  uint32_t nb_external_reference_symbols_ = 0;
 
-  uint32_t indirect_sym_offset_;
-  uint32_t nb_indirect_symbols_;
+  uint32_t indirect_sym_offset_ = 0;
+  uint32_t nb_indirect_symbols_ = 0;
 
-  uint32_t external_relocation_offset_;
-  uint32_t nb_external_relocations_;
+  uint32_t external_relocation_offset_ = 0;
+  uint32_t nb_external_relocations_ = 0;
 
-  uint32_t local_relocation_offset_;
-  uint32_t nb_local_relocations_;
+  uint32_t local_relocation_offset_ = 0;
+  uint32_t nb_local_relocations_ = 0;
 
   std::vector<Symbol*> indirect_symbols_;
 };

--- a/include/LIEF/MachO/DynamicSymbolCommand.hpp
+++ b/include/LIEF/MachO/DynamicSymbolCommand.hpp
@@ -48,6 +48,8 @@ class LIEF_API DynamicSymbolCommand : public LoadCommand {
 
   DynamicSymbolCommand(const details::dysymtab_command& cmd);
 
+  static DynamicSymbolCommand createForPython();
+
   DynamicSymbolCommand& operator=(const DynamicSymbolCommand& copy);
   DynamicSymbolCommand(const DynamicSymbolCommand& copy);
 

--- a/src/MachO/DynamicSymbolCommand.cpp
+++ b/src/MachO/DynamicSymbolCommand.cpp
@@ -24,41 +24,9 @@ namespace LIEF {
 namespace MachO {
 
 DynamicSymbolCommand::DynamicSymbolCommand() :
-  LoadCommand::LoadCommand{LOAD_COMMAND_TYPES::LC_DYSYMTAB, 0},
-  idx_local_symbol_{0},
-  nb_local_symbols_{0},
-
-  idx_external_define_symbol_{0},
-  nb_external_define_symbols_{0},
-
-  idx_undefined_symbol_{0},
-  nb_undefined_symbols_{0},
-
-  toc_offset_{0},
-  nb_toc_{0},
-
-  module_table_offset_{0},
-  nb_module_table_{0},
-
-  external_reference_symbol_offset_{0},
-  nb_external_reference_symbols_{0},
-
-  indirect_sym_offset_{0},
-  nb_indirect_symbols_{0},
-
-  external_relocation_offset_{0},
-  nb_external_relocations_{0},
-
-  local_relocation_offset_{0},
-  nb_local_relocations_{0}
+  LoadCommand::LoadCommand{LOAD_COMMAND_TYPES::LC_DYSYMTAB,
+                           sizeof(details::dysymtab_command)}
 {}
-
-DynamicSymbolCommand DynamicSymbolCommand::createForPython() {
-  auto cmd = DynamicSymbolCommand();
-  cmd.size(sizeof(details::dysymtab_command));
-  cmd.data(LoadCommand::raw_t(cmd.size(), 0));
-  return cmd;
-}
 
 DynamicSymbolCommand::DynamicSymbolCommand(const details::dysymtab_command& cmd) :
   LoadCommand::LoadCommand{static_cast<LOAD_COMMAND_TYPES>(cmd.cmd), cmd.cmdsize},

--- a/src/MachO/DynamicSymbolCommand.cpp
+++ b/src/MachO/DynamicSymbolCommand.cpp
@@ -53,6 +53,13 @@ DynamicSymbolCommand::DynamicSymbolCommand() :
   nb_local_relocations_{0}
 {}
 
+DynamicSymbolCommand DynamicSymbolCommand::createForPython() {
+  auto cmd = DynamicSymbolCommand();
+  cmd.size(sizeof(details::dysymtab_command));
+  cmd.data(LoadCommand::raw_t(cmd.size(), 0));
+  return cmd;
+}
+
 DynamicSymbolCommand::DynamicSymbolCommand(const details::dysymtab_command& cmd) :
   LoadCommand::LoadCommand{static_cast<LOAD_COMMAND_TYPES>(cmd.cmd), cmd.cmdsize},
 
@@ -320,4 +327,3 @@ std::ostream& DynamicSymbolCommand::print(std::ostream& os) const {
 
 }
 }
-


### PR DESCRIPTION
I created a static function (`createForPython`) to avoid messing with the implementation of the default constructor.