### PR TITLE
CMake: Fix checking Windows platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,15 +154,15 @@ else()
                         MbedTLS::mbedcrypto MbedTLS::mbedx509)
 endif()
 
-if(WINDOWS AND BUILD_SHARED_LIBS)
-  target_link_libraries(LIB_LIEF ws2_32)
+if(WIN32 AND BUILD_SHARED_LIBS)
+  target_link_libraries(LIB_LIEF PRIVATE ws2_32)
 endif()
 
 if(MSVC)
   add_compile_options(/bigobj)
 endif()
 
-if(CMAKE_BUILD_TYPE MATCHES Debug AND WINDOWS)
+if(CMAKE_BUILD_TYPE MATCHES Debug AND WIN32)
   add_definitions(-D_ITERATOR_DEBUG_LEVEL=0 -D_SECURE_SCL=0
                   -D_HAS_ITERATOR_DEBUGGING=0)
 endif()


### PR DESCRIPTION

    In CMake, WIN32 is true for any toolchain targeting Windows platform.
    See https://cmake.org/cmake/help/latest/variable/WIN32.html

