### PR TITLE
Removed _ITERATOR_DEBUG_LEVEL override on Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,11 +162,6 @@ if(MSVC)
   add_compile_options(/bigobj)
 endif()
 
-if(CMAKE_BUILD_TYPE MATCHES Debug AND WIN32)
-  add_definitions(-D_ITERATOR_DEBUG_LEVEL=0 -D_SECURE_SCL=0
-                  -D_HAS_ITERATOR_DEBUGGING=0)
-endif()
-
 if(CMAKE_BUILD_TYPE MATCHES Debug AND UNIX)
   target_compile_options(LIB_LIEF PRIVATE -g -O0)
 endif()


### PR DESCRIPTION
Fixes #948 
Summary:
Windows doesn't seem to let you link two objects when there is a mismatch between the value of `_ITERATOR_DEBUG_LEVEL` between them. The default value for `_ITERATOR_DEBUG_VALUE` on a Debug build is `2`, but LIEF is manually overwriting that value with `0`