### PR TITLE
Fix dos_stub write in PE builder

### DIFF
--- a/src/PE/Builder.cpp
+++ b/src/PE/Builder.cpp
@@ -450,7 +450,7 @@ ok_error_t Builder::build(const DosHeader& dos_header) {
     if (sizeof(details::pe_dos_header) + binary_->dos_stub().size() > dos_header.addressof_new_exeheader()) {
       LIEF_WARN("Inconsistent 'addressof_new_exeheader': 0x{:x}", dos_header.addressof_new_exeheader());
     }
-    ios_.write(binary_->dos_stub());
+    ios_.write(binary_->dos_stub().data(), binary_->dos_stub().size());
   }
 
   return ok();


### PR DESCRIPTION
Dear LIEF team!
This PR fixes the write of the PE's dos_stub, corrupted after invoking `LIEF::PE::Builder::build()`.

Reproduce with any Windows PE located at `in_path`:
```
int main(int argc, char** argv)
{
    auto pe = LIEF::PE::Parser::parse(in_path);
    LIEF::PE::Builder pe_builder(*pe);
    pe_builder.build();
    pe_builder.write(out_path);
    return 0;
}
```

`out_path` is corrupted:

<img width="1308" alt="dos_stub_bug" src="https://github.com/lief-project/LIEF/assets/94996651/50e886c2-f473-4499-b55c-7202d1dcb67d">

After this change, the original dos_stub is correctly stored.

Thanks for this excellent library!
Alex