### PR TITLE
Use list comprehension instead of map/filter in tutorial

### DIFF
--- a/doc/sphinx/tutorials/03_elf_change_symbols.rst
+++ b/doc/sphinx/tutorials/03_elf_change_symbols.rst
@@ -70,6 +70,7 @@ Basically, this program takes an integer as a parameter and performs some comput
 
 .. code-block:: console
 
+
   $ hashme 123
   228886645.836282
 
@@ -97,8 +98,8 @@ Then, we can change the name of the two imported functions in the **executable**
 
 .. code-block:: python
 
-  hashme_pow_sym = next(filter(lambda e : e.name == "pow", hashme.imported_symbols))
-  hashme_log_sym = next(filter(lambda e : e.name == "log", hashme.imported_symbols))
+  hashme_pow_sym = next(i for i in hashme.imported_symbols if i.name == "pow")
+  hashme_log_sym = next(i for i in hashme.imported_symbols if i.name == "log")
 
   hashme_pow_sym.name = "cos"
   hashme_log_sym.name = "sin"
@@ -116,14 +117,14 @@ And we need to do the same in the library: the ``log`` symbol's name is swapped 
 
 
   def swap(obj, a, b):
-      symbol_a = next(filter(lambda e : e.name == a, obj.dynamic_symbols))
-      symbol_b = next(filter(lambda e : e.name == b, obj.dynamic_symbols))
+      symbol_a = next(i for i in obj.dynamic_symbols if i.name == a)
+      symbol_b = next(i for i in obj.dynamic_symbols if i.name == b)
       b_name = symbol_b.name
       symbol_b.name = symbol_a.name
       symbol_a.name = b_name
 
-  hashme_pow_sym = next(filter(lambda e : e.name == "pow", hashme.imported_symbols))
-  hashme_log_sym = next(filter(lambda e : e.name == "log", hashme.imported_symbols))
+  hashme_pow_sym = next(i for i in hashme.imported_symbols if i.name == "pow")
+  hashme_log_sym = next(i for i in hashme.imported_symbols if i.name == "log")
 
   hashme_pow_sym.name = "cos"
   hashme_log_sym.name = "sin"

--- a/doc/sphinx/tutorials/07_pe_resource.rst
+++ b/doc/sphinx/tutorials/07_pe_resource.rst
@@ -68,7 +68,7 @@ The following snippet retrieves the :attr:`~lief.PE.RESOURCE_TYPES.MANIFEST` ele
   root = filezilla.resources
 
   # First level => Type ((ResourceDirectory node)
-  manifest_node = next(iter(filter(lambda e : e.id == lief.PE.RESOURCE_TYPES.MANIFEST, root.childs)))
+  manifest_node = next(i for i in root.childs if i.id == lief.PE.RESOURCE_TYPES.MANIFEST)
   print(manifest_node)
 
   # Second level => ID (ResourceDirectory node)


### PR DESCRIPTION
It's slightly clearer than a `next(map(filter(lambda ...)))` (imho). 