### PR TITLE
Remove verification of the non st_value for import function.

### DIFF
--- a/src/ELF/Symbol.cpp
+++ b/src/ELF/Symbol.cpp
@@ -214,8 +214,9 @@ bool Symbol::is_imported() const {
   // An import must not be defined in a section
   bool is_imported = shndx() == static_cast<uint16_t>(SYMBOL_SECTION_INDEX::SHN_UNDEF);
 
-  // An import must not have an address
-  is_imported = is_imported && value() == 0;
+  // An import must not have an address but mips and powerpc put an addres for
+  // import function.
+  //is_imported = is_imported && value() == 0;
 
   // its name must not be empty
   is_imported = is_imported && !name().empty();


### PR DESCRIPTION
mips and powerpc add a st_value for their import function (issue #796). So we need to remove this verification to let not to hide some import functions