### PR TITLE
ELF Python - fixing utf-8 encoding issue

### DIFF
--- a/api/python/src/ELF/objects/pyBinary.cpp
+++ b/api/python/src/ELF/objects/pyBinary.cpp
@@ -45,6 +45,7 @@
 
 #include "pyIterator.hpp"
 #include "pyErr.hpp"
+#include "pySafeString.hpp"
 
 namespace LIEF::ELF::py {
 using namespace LIEF::py;
@@ -625,7 +626,17 @@ void create<Binary>(nb::module_& m) {
 
     .def_prop_ro("strings",
         [] (const Binary& bin) {
-          return bin.strings();
+        const std::vector<std::string>& elf_strings = bin.strings();
+        std::vector<nb::object>  elf_strings_encoded;
+        elf_strings_encoded.reserve(elf_strings.size());
+
+        std::transform(
+                std::begin(elf_strings),
+                std::end(elf_strings),
+                std::back_inserter(elf_strings_encoded),
+                &safe_string);
+
+        return elf_strings_encoded;
         },
         "Return list of strings used in the current ELF file.\n"
         "Basically this function looks for strings in the ``.roadata`` section"_doc,


### PR DESCRIPTION
While trying to get the strings from an ELF file, I was getting the following error: 

`Exception in print_strings: 'utf-8' codec can't decode byte 0xaa in position 0: invalid start byte`

This PR contains the fix for the issue, and derived from this [previous commit](https://github.com/lief-project/LIEF/commit/c13d0c54fee914adf6b0fabc99801fd517e2d559)


I am observing this issue with all the ELF files I have tried. This can be reproduced by using the elf_reader.py example with `--strings` option. 

 - System and Version : MacOS 13.5.1, Python 3.11.5
 - Target format: ELF 
 - LIEF commit version:  Using the latest code from master. 