### PR TITLE
Fix LIEF::ELF::Binary::has_nx

### DIFF
--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -1146,7 +1146,7 @@ bool Binary::is_pie() const {
 
 bool Binary::has_nx() const {
   if (const Segment* gnu_stack = get(SEGMENT_TYPES::PT_GNU_STACK)) {
-    return gnu_stack->has(ELF_SEGMENT_FLAGS::PF_X);
+    return !gnu_stack->has(ELF_SEGMENT_FLAGS::PF_X);
   }
 
   if (header().machine_type() == ARCH::EM_PPC64) {


### PR DESCRIPTION
Hi!

I think the boolean expression returned by `LIEF::ELF::Binary::has_nx` has been mistakenly inverted in a previous commit: https://github.com/lief-project/LIEF/commit/97bf8b65ffecf22f896bbe1fc86bd3ae2949cb37

This commit fixes the regression.

Best regards,
Erwan