### PR TITLE
Ambiguous has_nx() patch

### DIFF
--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -208,11 +208,14 @@ bool Binary::is_pie() const {
 }
 
 
-bool Binary::has_nx() const {
-  if (!header().has(HEADER_FLAGS::MH_NO_HEAP_EXECUTION)) {
-    LIEF_INFO("Heap could be executable");
-  }
-  return !header().has(HEADER_FLAGS::MH_ALLOW_STACK_EXECUTION);
+// Function to check if there is NO_HEAP_EXECUTION set
+bool Binary::has_nx_heap() const {
+  return !header().has(HEADER_FLAGS::MH_NO_HEAP_EXECUTION);
+}
+
+// Function to check if MH_ALLOW_STACK_EXECUTION is set
+bool Binary::has_nx_stack() const {
+  return header().has(HEADER_FLAGS::MH_ALLOW_STACK_EXECUTION);
 }
 
 


### PR DESCRIPTION
### ISSUE CODE:
https://github.com/lief-project/LIEF/blob/66fcfcc4e7df350a98b212f99deaf607b1ee0324/src/MachO/Binary.cpp#L211

### DESCRIPTION
The `has_nx()` function for MachO binaries should work the other way around.
The first part of the function checks whether the binary allows heap execution (based on the absence of `MH_NO_HEAP_EXECUTION` flag):
```C
if (!header().has(HEADER_FLAGS::MH_NO_HEAP_EXECUTION)) {
  LIEF_INFO("Heap could be executable");
}
```
Then, the function returns the logical NOT (!) of whether the `MH_ALLOW_STACK_EXECUTION` flag is set in the binary's header. 
This means the function returns `true` if the `MH_ALLOW_STACK_EXECUTION` **flag is not set**, indicating that stack execution is not allowed.
```C
return !header().has(HEADER_FLAGS::MH_ALLOW_STACK_EXECUTION);
```

I see two issues here:
1. The function should distinguish between the executable heap region and the executable stack region - there should be two functions.
2. For the stack part (if MH_ALLOW_STACK_EXECUTION exists in binary header flags), it should return True, not False.
![image](https://github.com/lief-project/LIEF/assets/51202595/d5810df4-fb6d-48df-a16c-9cee2e4c0ea2)
```python
# Part of the code in my custom program that utilises lief:
return self.binary.has_nx
```

### SOLUTION
Here is my proposal to solve these problems:
```C
// Function to check if there is NO_HEAP_EXECUTION set
bool Binary::has_nx_heap() const {
  return !header().has(HEADER_FLAGS::MH_NO_HEAP_EXECUTION);
}

// Function to check if MH_ALLOW_STACK_EXECUTION is set
bool Binary::has_nx_stack() const {
  return header().has(HEADER_FLAGS::MH_ALLOW_STACK_EXECUTION);
}
```

To summarize:
* `has_nx_heap()` - should check if there is `NO_HEAP_EXECUTION` set, if it does not, it should return True.
* `has_nx_stack()` - should check if `MH_ALLOW_STACK_EXECUTION` is set, if it does, it should return true.

