### PR TITLE
fix pe relocations presence getter

### DIFF
--- a/include/LIEF/PE/Binary.hpp
+++ b/include/LIEF/PE/Binary.hpp
@@ -273,7 +273,7 @@ class LIEF_API Binary : public LIEF::Binary {
   //!
   //! @see Relocation
   bool has_relocations() const {
-    return relocations_.empty();
+    return !relocations_.empty();
   }
 
   //! Check if the current binary contains debug information


### PR DESCRIPTION
In Binary.hpp, the has_relocations() check has the opposite effect to what is intended

```
  //! Check if the current binary has relocations
  //!
  //! @see Relocation
  bool has_relocations() const {
    return relocations_.empty(); 
  }
```

This results in behaviour like this:

```
      print(self._pe.has_relocations)  # False
      self._pe.concrete.remove_all_relocations()
      print(self._pe.has_relocations) # True
      self._pe.add_relocation(lief.PE.Relocation())
      print(self._pe.has_relocations) # False
```

And messes up anything LIEF does with relocations, such as preventing relocations from being built.