### PR TITLE
Add usable constructor for MachO::BuildVersion

### DIFF
--- a/include/LIEF/MachO/BuildVersion.hpp
+++ b/include/LIEF/MachO/BuildVersion.hpp
@@ -53,6 +53,10 @@ class LIEF_API BuildVersion : public LoadCommand {
   public:
   BuildVersion();
   BuildVersion(const details::build_version_command& version_cmd);
+  BuildVersion(const PLATFORMS platform,
+               const version_t &minos,
+               const version_t &sdk,
+               const tools_list_t &tools);
 
   BuildVersion& operator=(const BuildVersion& copy);
   BuildVersion(const BuildVersion& copy);

--- a/src/MachO/BuildVersion.cpp
+++ b/src/MachO/BuildVersion.cpp
@@ -45,6 +45,18 @@ BuildVersion::BuildVersion(const details::build_version_command& ver) :
 {
 }
 
+BuildVersion::BuildVersion(const PLATFORMS platform,
+                           const version_t &minos,
+                           const version_t &sdk,
+                           const tools_list_t &tools) :
+  LoadCommand::LoadCommand{LOAD_COMMAND_TYPES::LC_BUILD_VERSION,
+                           static_cast<uint32_t>(sizeof(details::build_version_command) +
+                           sizeof(details::build_tool_version) * tools.size())},
+  platform_{platform}, minos_{minos}, sdk_{sdk}, tools_{tools}
+{
+  original_data_.resize(size());
+}
+
 BuildVersion* BuildVersion::clone() const {
   return new BuildVersion(*this);
 }


### PR DESCRIPTION
I use this in [dylibify](https://github.com/jevinskie/dylibify/blob/7c84ace9b0efb6d458f243575d60b0d7473130d6/cpp/dylibify-lief-cpp.cpp#L286-L300) to modify (via delete then create [what this PR is for]) the platform from iOS to macOS while converting the executable to a dylib. Similar type functionality is provided by vtool in Xcode/Command Line Tools.