### PR TITLE
fix the bug in symbol.section_number to section

### DIFF
--- a/src/PE/Parser.cpp
+++ b/src/PE/Parser.cpp
@@ -548,8 +548,8 @@ ok_error_t Parser::parse_symbols() {
     }
 
     if (symbol.section_number() > 0 &&
-        static_cast<uint32_t>(symbol.section_number()) < binary_->sections_.size()) {
-      symbol.section_ = binary_->sections_[symbol.section_number()].get();
+        static_cast<uint32_t>(symbol.section_number()) <= binary_->sections_.size()) {
+      symbol.section_ = binary_->sections_[symbol.section_number()-1].get();
     }
 
     for (uint32_t i = 0; i < raw_symbol.NumberOfAuxSymbols; ++i) {


### PR DESCRIPTION
According to the coff format document : https://www.delorie.com/djgpp/doc/coff/symtab.html

The number of the section that this symbol belongs to. The first section in [the section table](https://www.delorie.com/djgpp/doc/coff/scnhdr.html) is section one.

![image](https://github.com/lief-project/LIEF/assets/11813461/8f0226e8-c937-4bc3-ac9a-3e696660fff3)





 