### PR TITLE
fix ASN1Reader::tag2str

### DIFF
--- a/src/BinaryStream/ASN1Reader.cpp
+++ b/src/BinaryStream/ASN1Reader.cpp
@@ -473,6 +473,10 @@ std::string ASN1Reader::tag2str(int tag) {
   HANDLE(ASN1_CONSTRUCTED);
   HANDLE(ASN1_CONTEXT_SPECIFIC);
 
+  if (tag_str.size() < 3) {
+    return "MBEDTLS_ASN1_UNKNOWN";
+  }
+
   return tag_str.substr(3);
 #undef HANDLE
 }


### PR DESCRIPTION
This PR will fix #1046.

This pull request adds a string length check before executing the `substr` in the `std::string ASN1Reader::tag2str` function.

Specifically, the function has been changed to return `MBEDTLS_ASN1_UNKNOWN` if the size of `tag_str` is less than 3.
