### PR TITLE
Add additional missing undef for ELF

### DIFF
--- a/include/LIEF/ELF/undef.h
+++ b/include/LIEF/ELF/undef.h
@@ -484,6 +484,7 @@
 
 #undef PT_GNU_STACK
 #undef PT_GNU_RELRO
+#undef PT_GNU_PROPERTY
 
 #undef PT_ARM_ARCHEXT
 
@@ -538,6 +539,7 @@
 
 #undef DT_PREINIT_ARRAY
 #undef DT_PREINIT_ARRAYSZ
+#undef DT_SYMTAB_SHNDX
 
 #undef DT_LOOS
 #undef DT_HIOS


### PR DESCRIPTION
Program fails to build when `elf.h` (or `boost/dll/shared_library.hpp`) is included before `LIEF.hpp`.
Example: 
```cpp
// test.cpp, g++ -std=c++17 test.cpp
#include <elf.h>
#include "LIEF/LIEF.hpp"
int main(void) {
    return 0;
}
```
Environment: 
LIEF: v0.14.1
OS: Arch Linux x86_64 6.9.3-arch1-1
GCC: 14.1.1