### PR TITLE
Add cstdint header for uint64_t type

### DIFF
--- a/include/LIEF/Abstract/Header.hpp
+++ b/include/LIEF/Abstract/Header.hpp
@@ -16,6 +16,7 @@
 #ifndef LIEF_ABSTRACT_HEADER_H
 #define LIEF_ABSTRACT_HEADER_H
 
+#include <cstdint> // for uint64_t
 #include <ostream>
 #include <set>
 


### PR DESCRIPTION
Compile error encountered on Ubuntu Linux:

In file included from src/Abstract/Header.cpp:20:
include/LIEF/Abstract/Header.hpp:39:3: error: ‘uint64_t’ does not name a type
   39 |   uint64_t               entrypoint()   const;
      |   ^~~~~~~~
include/LIEF/Abstract/Header.hpp:26:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   25 | #include "LIEF/Abstract/enums.hpp"
  +++ |+#include <cstdint>
   26 | 
