### PR TITLE
Add rustls-tls feature to reqwest

### DIFF
--- a/api/rust/cargo/lief-build/Cargo.toml
+++ b/api/rust/cargo/lief-build/Cargo.toml
@@ -8,7 +8,12 @@ license.workspace = true
 
 [dependencies]
 miette        = { version="5.10", features = [ "fancy" ] }
-reqwest       = { version = "0.11.24", features = ["blocking"] }
+reqwest       = { version = "0.11.24", features = ["blocking"], default-features = false}
 zip           = "0.6.6"
 git-version   = "0.3.9"
 semver        = "1.0.22"
+
+[features]
+default=["rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/default-tls"]

--- a/api/rust/cargo/lief-ffi/Cargo.toml
+++ b/api/rust/cargo/lief-ffi/Cargo.toml
@@ -13,3 +13,7 @@ autocxx = "0.26"
 [build-dependencies]
 lief-build = { version="0.16.0", path = "../lief-build" }
 miette     = { version="5.10", features = [ "fancy" ] }
+
+[features]
+default = ["rustls-tls"]
+rustls-tls = ["lief-build/rustls-tls"]

--- a/api/rust/cargo/lief/Cargo.toml
+++ b/api/rust/cargo/lief/Cargo.toml
@@ -22,3 +22,7 @@ num-traits = "0.2"
 num-derive = "0.4"
 num-bigint = "0.4"
 lief-ffi   = { version = "0.16.0", path = "../lief-ffi" }
+
+[features]
+default = ["rustls-tls"]
+rustls-tls = ["lief-ffi/rustls-tls"]


### PR DESCRIPTION
The rust bindings use reqwest to download prebuilt binaries and link against those. This is done via an HTTPS request, and TLS is provided by using openssl. When building via nix, this is an issue since it requires having openssl present so it can link against it.
By adding the rusttls-tls feature to reqwest, it uses a pure rust implementation of TLS, simplifying the building process.