### PR TITLE
Fix bug in Python PE Binary bindings caused by copy

### DIFF
--- a/api/python/src/PE/objects/pyBinary.cpp
+++ b/api/python/src/PE/objects/pyBinary.cpp
@@ -316,7 +316,8 @@ void create<Binary>(nb::module_& m) {
     .def("add_relocation",
         &Binary::add_relocation,
         "Add a " RST_CLASS_REF(lief.PE.Relocation) " to the binary"_doc,
-        "relocation"_a)
+        "relocation"_a,
+        nb::rv_policy::reference_internal)
 
     .def("remove_all_relocations", &Binary::remove_all_relocations)
 


### PR DESCRIPTION
Python: mark add_relocation return value as reference
Makes the return value from the PE::Binary add_relocation method an internal reference.

Without this, the object returned by `add_relocation` is a copy of the one held by `Binary`, so modifications to that object are independent.

This is similar to #1106 

Test case:
```
import lief
b = lief.PE.Binary(lief.PE.PE_TYPE.PE32)
r = lief.PE.Relocation()
s = b.add_relocation(r)
assert r is not s
assert list(b.relocations)[0] is s
```