### PR TITLE
Speed up ELF symbol lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 api/rust/cargo/target/*
 api/rust/examples/target/*
 Cargo.lock
+.cache

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -75,7 +75,7 @@ foreach(example ${LIEF_CPP_EXAMPLES})
   set_target_properties(
     ${output_name}
     PROPERTIES POSITION_INDEPENDENT_CODE ON
-               CXX_STANDARD              11
+               CXX_STANDARD              17
                CXX_STANDARD_REQUIRED     ON)
 
   target_link_libraries(${output_name} PUBLIC LIB_LIEF)

--- a/include/LIEF/ELF/Binary.hpp
+++ b/include/LIEF/ELF/Binary.hpp
@@ -16,7 +16,9 @@
 #ifndef LIEF_ELF_BINARY_H
 #define LIEF_ELF_BINARY_H
 
+#include <string_view>
 #include <vector>
+#include <map>
 #include <memory>
 
 #include "LIEF/visibility.h"
@@ -149,6 +151,9 @@ class LIEF_API Binary : public LIEF::Binary {
 
   //! Internal container for storing ELF's Symbol
   using symbols_t = std::vector<std::unique_ptr<Symbol>>;
+
+  //! Internal container for fast lookup of symbols
+  using symbol_indices_t = std::map<std::string_view, uint32_t>;
 
   //! Iterator which outputs the Dynamic Symbol& object
   using it_dynamic_symbols = ref_iterator<symbols_t&, Symbol*>;
@@ -1021,6 +1026,8 @@ class LIEF_API Binary : public LIEF::Binary {
   dynamic_entries_t dynamic_entries_;
   symbols_t dynamic_symbols_;
   symbols_t symtab_symbols_;
+  symbol_indices_t dynamic_symbol_indices_;
+  symbol_indices_t symtab_symbol_indices_;
   relocations_t relocations_;
   symbols_version_t symbol_version_table_;
   symbols_version_requirement_t symbol_version_requirements_;

--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -1198,6 +1198,7 @@ ok_error_t Parser::parse_symtab_symbols(uint64_t offset, uint32_t nb_symbols,
     }
     link_symbol_section(*symbol);
     binary_->symtab_symbols_.push_back(std::move(symbol));
+    binary_->symtab_symbol_indices_.insert({binary_->symtab_symbols_.back()->name(), binary_->symtab_symbols_.size() - 1});
   }
   return ok();
 }
@@ -1257,6 +1258,7 @@ ok_error_t Parser::parse_dynamic_symbols(uint64_t offset) {
     }
     link_symbol_section(*symbol);
     binary_->dynamic_symbols_.push_back(std::move(symbol));
+    binary_->dynamic_symbol_indices_.insert({binary_->dynamic_symbols_.back()->name(), binary_->dynamic_symbols_.size() - 1});
   }
   binary_->sizing_info_->dynsym = binary_->dynamic_symbols_.size() * sizeof(Elf_Sym);
   if (const auto* dt_strsz = binary_->get(DynamicEntry::TAG::STRSZ)) {


### PR DESCRIPTION
It's too slow to rebuild an ELF object that contains a large number of symbols. This happens because the frequent linear looking up was expensive.