### PR TITLE
Fix ELF/MachO to point empty symbol names to offet 0, required to be NUL

### DIFF
--- a/src/internal_utils.hpp
+++ b/src/internal_utils.hpp
@@ -100,7 +100,7 @@ std::vector<std::string> optimize(const HANDLER& container,
   std::vector<std::string> string_table_optimized;
   string_table_optimized.reserve(container.size());
 
-  // reverse all symbol names and sort them so we can merge then in the linear time:
+  // reverse all symbol names and sort them so we can merge them in the linear time:
   // aaa, aadd, aaaa, cca, ca -> aaaa, aaa, acc, ac ddaa
   std::transform(std::begin(container), std::end(container),
                  std::inserter(string_table, std::end(string_table)),
@@ -126,7 +126,7 @@ std::vector<std::string> optimize(const HANDLER& container,
   );
 
   // as all elements that can be merged are adjacent we can just go through the list once
-  // and memorize one we merged to calculate the offsets later
+  // and memorize ones we merged to calculate the offsets later
   std::unordered_map<std::string, std::string> merged_map;
   size_t to_set_idx = 0, cur_elm_idx = 1;
   for (; cur_elm_idx < string_table_optimized.size(); ++cur_elm_idx) {
@@ -163,12 +163,17 @@ std::vector<std::string> optimize(const HANDLER& container,
   if (of_map_p != nullptr) {
     std::unordered_map<std::string, size_t>& offset_map = *of_map_p;
     offset_map[""] = 0;
+
     for (const auto &v : string_table_optimized) {
-      offset_map[v] = offset_counter;
-      offset_counter += v.size() + 1;
+      if (!v.empty()) {
+        offset_map[v] = offset_counter;
+        offset_counter += v.size() + 1;
+      }
     }
     for (const auto &kv : merged_map) {
-      offset_map[kv.first] = offset_map[kv.second] + (kv.second.size() - kv.first.size());
+      if (!kv.first.empty()) {
+        offset_map[kv.first] = offset_map[kv.second] + (kv.second.size() - kv.first.size());
+      }
     }
   }
 

--- a/tests/elf/test_1124.py
+++ b/tests/elf/test_1124.py
@@ -1,0 +1,22 @@
+import lief
+from pathlib import Path
+
+from utils import get_sample
+
+def test_1124(tmp_path: Path):
+    """
+    Test for the PR #1124 in which there are multiple "empty" strings
+
+    https://github.com/lief-project/LIEF/pull/1124
+    """
+
+    elf = lief.ELF.parse(get_sample("ELF/cordic.ko"))
+    out = tmp_path / "cordic.ko"
+    elf.write(out.as_posix())
+
+    cordic = lief.ELF.parse(out)
+    symtab = cordic.symtab_symbols
+
+    assert symtab[1].section.name == ".text"
+    assert symtab[2].section.name == "__ksymtab_strings"
+    assert symtab[35].name == "cordic_calc_iq"


### PR DESCRIPTION
ELF/MachO symtab entries with NUL name should use zero offset into strtab.

I ran `ninja test` but unittests seemed to run awfully quickly. Maybe GitHub CI will be more thorough?