### PR TITLE
Introducing LIEF Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@
   <a href="https://twitter.com/LIEF_project">
    <img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/lief_project">
   </a>
+  &nbsp;
+  <a href="https://gurubase.io/g/lief">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20LIEF%20Guru-006BFF">
+  </a>
 </p>
 
 <br />


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [LIEF Guru](https://gurubase.io/g/lief) to Gurubase. LIEF Guru uses the data from this repo and data from the [docs](https://lief.re/doc/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "LIEF Guru", which highlights that LIEF now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable LIEF Guru in Gurubase, just let me know that's totally fine.
