### PR TITLE
Fix MachO::Binary::shift_command 

### DIFF
--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -618,7 +618,7 @@ void Binary::shift_command(size_t width, uint64_t from_offset) {
   uint64_t virtual_address = 0;
 
   if (segment != nullptr) {
-    virtual_address = segment->virtual_address() + from_offset;
+    virtual_address = segment->virtual_address() + from_offset - segment->file_offset();
   }
 
   if (const SegmentCommand* text = get_segment("__TEXT")) {

--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -640,9 +640,8 @@ void Binary::shift_command(size_t width, uint64_t from_offset) {
 
     for (std::unique_ptr<Symbol>& s : symbols_) {
       if (s->type() == Symbol::TYPE::SECTION) {
-        uint64_t value = s->value();
-        if (value > from_offset) {
-          s->value(value + width);
+        if (s->value() > virtual_address) {
+          s->value(s->value() + width);
         }
       }
     }

--- a/tests/macho/test_symbols.py
+++ b/tests/macho/test_symbols.py
@@ -131,22 +131,20 @@ def test_demangling():
     assert macho.symbols[1].demangled_name == "void __cxxabiv1::(anonymous namespace)::demangle<__cxxabiv1::(anonymous namespace)::Db>(char const*, char const*, __cxxabiv1::(anonymous namespace)::Db&, int&)"
     assert macho.symbols[486].demangled_name == "___cxa_deleted_virtual"
 
-def test_symbol_shift(tmp_path):
+def test_symbol_shift():
     bin_path = pathlib.Path(get_sample("MachO/MachO64_x86-64_binary_sym2remove.bin"))
-    bin = lief.parse(bin_path.as_posix())
-    output = f"{tmp_path}/{bin_path.name}"
+    macho = lief.MachO.parse(bin_path.as_posix()).at(0)
 
     shift = 0x4000
-    loadcommands_end = bin.imagebase + 32 + bin.header.sizeof_cmds # sizeof(mach_header_64) + size of load command table
+    loadcommands_end = macho.imagebase + 32 + macho.header.sizeof_cmds # sizeof(mach_header_64) + size of load command table
     def get_shifted_symbol(sym):
         value = sym.value
         if value > loadcommands_end:
             value += shift
         return (sym.name, value)
 
-    check_symbols = {get_shifted_symbol(sym) for sym in bin.symbols if sym.raw_type & 0x0E == lief.MachO.Symbol.TYPE.SECTION}
-    bin.shift(shift)
-    shifted_symbols = {(sym.name, sym.value) for sym in bin.symbols if sym.raw_type & 0x0E == lief.MachO.Symbol.TYPE.SECTION}
+    check_symbols = {get_shifted_symbol(sym) for sym in macho.symbols if sym.raw_type & 0x0E == lief.MachO.Symbol.TYPE.SECTION}
+    macho.shift(shift)
+    shifted_symbols = {(sym.name, sym.value) for sym in macho.symbols if sym.raw_type & 0x0E == lief.MachO.Symbol.TYPE.SECTION}
 
     assert shifted_symbols == check_symbols
-


### PR DESCRIPTION
* Function argument `from_offset` is a file offset that we need to adjust before adding to VA of segment.

* Fix adjustments of symbols: their values should be compared to VA instead of file offset.
