### PR TITLE
Update segment offsets in MachO::Binary::extend_segment

### DIFF
--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -1236,6 +1236,7 @@ bool Binary::extend_segment(const SegmentCommand& segment, size_t size) {
   target_segment->virtual_size(target_segment->virtual_size() + size_aligned);
   target_segment->file_size(target_segment->file_size() + size_aligned);
   target_segment->content_resize(target_segment->file_size());
+  refresh_seg_offset();
   return true;
 }
 


### PR DESCRIPTION
`LIEF::MachO::Binary::extend_segment` changes `file_offset` of some segments, therefore we need to call `refresh_seg_offset` to update offset cache.