### PR TITLE
MachO::Binary::shift_command: fix exports of dyld

### DIFF
--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -816,7 +816,7 @@ void Binary::shift_command(size_t width, uint64_t from_offset) {
 
   if (DyldExportsTrie* exports = dyld_exports_trie()) {
     for (ExportInfo& info : exports->exports()) {
-      if (virtual_address >= info.address()) {
+      if (info.address() > from_offset) {
         info.address(info.address() + width);
       }
     }

--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -769,7 +769,7 @@ void Binary::shift_command(size_t width, uint64_t from_offset) {
     // Shift Export Info
     // -----------------
     for (ExportInfo& info : dyld->exports()) {
-      if (info.address() > virtual_address) {
+      if (info.address() > from_offset) {
         info.address(info.address() + width);
       }
     }

--- a/tests/macho/test_symbols.py
+++ b/tests/macho/test_symbols.py
@@ -166,3 +166,21 @@ def test_exports_after_shift(tmp_path):
     macho.shift(shift)
     new_exports_addrs = [e.address for e in macho.dyld_info.exports]
     assert new_exports_addrs == expected_exports_addrs
+
+def test_chained_exports_after_shift(tmp_path):
+    bin_path = pathlib.Path(get_sample("MachO/MachO64_AArch64_weak-sym-fc.bin"))
+    macho = lief.MachO.parse(bin_path.as_posix()).at(0)
+    assert macho.dyld_exports_trie
+
+    shift = 0x10000
+    loadcommands_end = 32 + macho.header.sizeof_cmds # sizeof(mach_header_64) + size of load command table
+    def get_shifted_export(e):
+        address = e.address
+        if address > loadcommands_end:
+            address += shift
+        return address
+
+    expected_exports_addrs = [get_shifted_export(e) for e in macho.dyld_exports_trie.exports]
+    macho.shift(shift)
+    new_exports_addrs = [e.address for e in macho.dyld_exports_trie.exports]
+    assert new_exports_addrs == expected_exports_addrs

--- a/tests/macho/test_symbols.py
+++ b/tests/macho/test_symbols.py
@@ -3,7 +3,7 @@ import pytest
 import lief
 import pathlib
 import re
-from utils import is_osx, get_sample
+from utils import is_aarch64, is_osx, get_sample
 
 from .test_builder import run_program
 
@@ -148,3 +148,21 @@ def test_symbol_shift():
     shifted_symbols = {(sym.name, sym.value) for sym in macho.symbols if sym.raw_type & 0x0E == lief.MachO.Symbol.TYPE.SECTION}
 
     assert shifted_symbols == check_symbols
+
+def test_exports_after_shift(tmp_path):
+    bin_path = pathlib.Path(get_sample("MachO/MachO64_AArch64_weak-sym.bin"))
+    macho = lief.MachO.parse(bin_path.as_posix()).at(0)
+    assert macho.dyld_info
+
+    shift = 0x10000
+    loadcommands_end = 32 + macho.header.sizeof_cmds # sizeof(mach_header_64) + size of load command table
+    def get_shifted_export(e):
+        address = e.address
+        if address > loadcommands_end:
+            address += shift
+        return address
+
+    expected_exports_addrs = [get_shifted_export(e) for e in macho.dyld_info.exports]
+    macho.shift(shift)
+    new_exports_addrs = [e.address for e in macho.dyld_info.exports]
+    assert new_exports_addrs == expected_exports_addrs


### PR DESCRIPTION
Despite the field name `address` it stores a file offset.