### PR TITLE
MachO::Binary: improve code related to shift method

### DIFF
--- a/include/LIEF/MachO/Binary.hpp
+++ b/include/LIEF/MachO/Binary.hpp
@@ -982,6 +982,11 @@ class LIEF_API Binary : public LIEF::Binary  {
   LIEF_LOCAL LIEF::Binary::functions_t get_abstract_imported_functions() const override;
   LIEF_LOCAL std::vector<std::string> get_abstract_imported_libraries() const override;
 
+  /// Check that a gap between the load command table and
+  /// the first section is at least \p size bytes.
+  /// If there is not enough space, the gap is grown using \ref shift method.
+  ok_error_t ensure_command_space(size_t size);
+
   relocations_t& relocations_list() {
     return this->relocations_;
   }
@@ -1013,7 +1018,7 @@ class LIEF_API Binary : public LIEF::Binary  {
 
   // Cached relocations from segment / sections
   mutable relocations_t relocations_;
-  int32_t available_command_space_ = 0;
+  size_t available_command_space_ = 0;
 
   // This is used to improve performances of
   // offset_to_virtual_address

--- a/include/LIEF/utils.hpp
+++ b/include/LIEF/utils.hpp
@@ -33,6 +33,16 @@ inline uint64_t align(uint64_t value, uint64_t align_on) {
   return value;
 }
 
+inline uint64_t align_down(uint64_t value, uint64_t align_on) {
+  if (align_on == 0) {
+    return value;
+  }
+  const auto r = value % align_on;
+  if (r > 0) {
+    return value - r;
+  }
+  return value;
+}
 
 template<typename T>
 inline constexpr T round(T x) {

--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -850,8 +850,16 @@ void Binary::shift_command(size_t width, uint64_t from_offset) {
 
 }
 
+ok_error_t Binary::ensure_command_space(size_t size) {
+  if (available_command_space_ < size) {
+    return shift(size);
+  }
+  return ok();
+}
 
 ok_error_t Binary::shift(size_t value) {
+  value = align(value, page_size());
+
   Header& header = this->header();
 
   // Offset of the load commands table
@@ -935,23 +943,19 @@ ok_error_t Binary::shift(size_t value) {
     }
   }
   refresh_seg_offset();
+  available_command_space_ += value;
   return ok();
 }
 
 LoadCommand* Binary::add(std::unique_ptr<LoadCommand> command) {
-  static constexpr uint32_t shift_value = 0x4000;
   const int32_t size_aligned = align(command->size(), pointer_size());
 
-  // Check there is enough spaces between the load command table
-  // and the raw content
-  if (available_command_space_ < size_aligned) {
-    if (!shift(shift_value)) {
-      return nullptr;
-    }
-    available_command_space_ += shift_value;
-    return add(std::move(command));
+  // Check there is enough space between the
+  // load command table and the raw content
+  if (auto result = ensure_command_space(size_aligned); is_err(result)) {
+    LIEF_ERR("Failed to ensure command space {}: {}", size_aligned, to_string(get_error(result)));
+    return nullptr;
   }
-
   available_command_space_ -= size_aligned;
 
   Header& header = this->header();
@@ -999,27 +1003,20 @@ LoadCommand* Binary::add(std::unique_ptr<LoadCommand> command) {
 }
 
 LoadCommand* Binary::add(const LoadCommand& command, size_t index) {
-  static constexpr uint32_t shift_value = 0x4000;
-
   // If index is "too" large <=> push_back
   if (index >= commands_.size()) {
     return add(command);
   }
 
-  int32_t size_aligned = align(command.size(), pointer_size());
+  const size_t size_aligned = align(command.size(), pointer_size());
   LIEF_DEBUG("available_command_space_: 0x{:06x} (required: 0x{:06x})",
              available_command_space_, size_aligned);
 
-  // Check that we have enough space
-  if (available_command_space_ <= size_aligned) {
-    shift(shift_value);
-    available_command_space_ += shift_value;
-    return add(command, index);
+  if (auto result = ensure_command_space(size_aligned); is_err(result)) {
+    LIEF_ERR("Failed to ensure command space {}: {}", size_aligned, to_string(get_error(result)));
+    return nullptr;
   }
-  LIEF_DEBUG("No need to shift");
-
   available_command_space_ -= size_aligned;
-
 
   // Update the Header according to the new command
   Header& header = this->header();
@@ -1148,8 +1145,6 @@ const LoadCommand* Binary::get(LoadCommand::TYPE type) const {
 }
 
 bool Binary::extend(const LoadCommand& command, uint64_t size) {
-  static constexpr uint32_t shift_value = 0x10000;
-
   const auto it = std::find_if(
       std::begin(commands_), std::end(commands_),
       [&command] (const std::unique_ptr<LoadCommand>& cmd) {
@@ -1162,27 +1157,26 @@ bool Binary::extend(const LoadCommand& command, uint64_t size) {
   }
 
   LoadCommand* cmd = it->get();
-  const int32_t size_aligned = align(cmd->size() + size, pointer_size());
-  const uint32_t extension = size_aligned - cmd->size();
-  if (available_command_space_ < size_aligned) {
-    shift(shift_value);
-    available_command_space_ += shift_value;
-    return extend(command, size);
+  const size_t size_aligned = align(size, pointer_size());
+  if (auto result = ensure_command_space(size_aligned); is_err(result)) {
+    LIEF_ERR("Failed to ensure command space {}: {}", size_aligned, to_string(get_error(result)));
+    return false;
   }
+  available_command_space_ -= size_aligned;
 
   for (std::unique_ptr<LoadCommand>& lc : commands_) {
     if (lc->command_offset() > cmd->command_offset()) {
-      lc->command_offset(lc->command_offset() + extension);
+      lc->command_offset(lc->command_offset() + size_aligned);
     }
   }
 
-  cmd->size(size_aligned);
-  cmd->original_data_.resize(size_aligned);
+  cmd->size(cmd->size() + size_aligned);
+  cmd->original_data_.resize(cmd->original_data_.size() + size_aligned);
 
   // Update Header
   // =============
   Header& header = this->header();
-  header.sizeof_cmds(header.sizeof_cmds() + extension);
+  header.sizeof_cmds(header.sizeof_cmds() + size_aligned);
 
   return true;
 }
@@ -1325,7 +1319,6 @@ Section* Binary::add_section(const Section& section) {
   return add_section(*_TEXT_segment, section);
 }
 
-
 Section* Binary::add_section(const SegmentCommand& segment, const Section& section) {
 
   const auto it_segment = std::find_if(
@@ -1345,20 +1338,18 @@ Section* Binary::add_section(const SegmentCommand& segment, const Section& secti
 
   const size_t sec_size = is64_ ? sizeof(details::section_64) :
                                   sizeof(details::section_32);
-  const size_t data_size = content.size();
-  const int32_t needed_size = align(sec_size + data_size, page_size());
-  if (available_command_space_ < needed_size) {
-    shift(needed_size);
-    available_command_space_ += needed_size;
-    return add_section(segment, section);
+  const size_t size_aligned = align(content.size(), 1 << section.alignment());
+  if (auto result = ensure_command_space(sec_size + size_aligned); is_err(result)) {
+    LIEF_ERR("Failed to ensure command space {}: {}", sec_size + size_aligned, to_string(get_error(result)));
+    return nullptr;
   }
 
-  if (!extend(*target_segment, sec_size)) {
+  if (!extend(*target_segment, sec_size)) { // adjusts available_command_space_
     LIEF_ERR("Unable to extend segment '{}' by 0x{:x}", segment.name(), sec_size);
     return nullptr;
   }
 
-  available_command_space_ -= needed_size;
+  available_command_space_ -= size_aligned;
 
   auto new_section = std::make_unique<Section>(section);
   // Compute offset, virtual address etc for the new section
@@ -1369,12 +1360,12 @@ Section* Binary::add_section(const SegmentCommand& segment, const Section& secti
     uint64_t new_offset = is64_ ? sizeof(details::mach_header_64) :
                                   sizeof(details::mach_header);
     new_offset += header().sizeof_cmds();
-    new_offset += available_command_space_;
+    new_offset += available_command_space_; // == space after mach_header minus size of section
     new_section->offset(new_offset);
   }
 
   if (section.size() == 0) {
-    new_section->size(data_size);
+    new_section->size(size_aligned);
   }
 
   if (section.virtual_address() == 0) {

--- a/tests/macho/test_builder.py
+++ b/tests/macho/test_builder.py
@@ -13,6 +13,10 @@ from utils import get_sample, is_apple_m1, is_osx, is_x86_64, sign, chmod_exe, i
 
 lief.logging.set_level(lief.logging.LEVEL.INFO)
 
+def align_to(value, alignment):
+    # llvm::alignTo
+    return (value + alignment - 1) & ~(alignment - 1)
+
 def dyld_check(path: str):
     dyld_info_path = "/usr/bin/dyld_info"
     if not pathlib.Path(dyld_info_path).exists():
@@ -154,6 +158,25 @@ def test_extend_cmd(tmp_path):
 
     assert new[lief.MachO.LoadCommand.TYPE.UUID].size == original_size + 0x4000
 
+def verify_sections_continuity(binary):
+    # Check that sections are continuous and non-overlapping in each segment
+    bad_section_types = [
+            lief.MachO.Section.TYPE.ZEROFILL,
+            lief.MachO.Section.TYPE.THREAD_LOCAL_ZEROFILL,
+            lief.MachO.Section.TYPE.GB_ZEROFILL,
+            ]
+    for segment in binary.segments:
+        if len(segment.sections) == 0:
+            continue
+        sections = sorted([s for s in segment.sections if s.type not in bad_section_types], key=lambda s: s.offset)
+        next_expected_offset = sections[0].offset
+        assert sections[0].offset % (1 << sections[0].alignment) == 0
+        for section in sections:
+            next_expected_offset = align_to(next_expected_offset, 1 << section.alignment)
+            assert section.offset % (1 << section.alignment) == 0
+            assert section.offset == next_expected_offset
+            next_expected_offset += section.size
+
 def test_add_section_id(tmp_path):
     bin_path = pathlib.Path(get_sample("MachO/MachO64_x86-64_binary_id.bin"))
     original = lief.MachO.parse(bin_path.as_posix()).at(0)
@@ -163,6 +186,8 @@ def test_add_section_id(tmp_path):
     for i in range(50):
         section = lief.MachO.Section(f"__lief_{i}", [0x90] * 0x100)
         original.add_section(section)
+
+    verify_sections_continuity(original)
 
     assert original.virtual_size % original.page_size == 0
 

--- a/tests/macho/test_builder.py
+++ b/tests/macho/test_builder.py
@@ -15,6 +15,7 @@ lief.logging.set_level(lief.logging.LEVEL.INFO)
 
 def align_to(value, alignment):
     # llvm::alignTo
+    assert (alignment & (alignment - 1)) == 0 # is power of two
     return (value + alignment - 1) & ~(alignment - 1)
 
 def dyld_check(path: str):


### PR DESCRIPTION
This commit outlines common pattern in the code into `ensure_command_space` method that checks if there is enough space between the command table and the first section.

Additionally this commit changes `add_section` alignment from a size of a page to the section alignment requested by user.