### PR TITLE
Move destructor of ChainedBindingInfo out of the header

### DIFF
--- a/include/LIEF/MachO/ChainedBindingInfo.hpp
+++ b/include/LIEF/MachO/ChainedBindingInfo.hpp
@@ -99,9 +99,7 @@ class LIEF_API ChainedBindingInfo : public BindingInfo {
     return info->type() == TYPES::CHAINED;
   }
 
-  ~ChainedBindingInfo() override {
-    clear();
-  }
+  ~ChainedBindingInfo() override;
 
   void accept(Visitor& visitor) const override;
 

--- a/src/MachO/ChainedBindingInfo.cpp
+++ b/src/MachO/ChainedBindingInfo.cpp
@@ -46,6 +46,10 @@ ChainedBindingInfo::ChainedBindingInfo(DYLD_CHAINED_FORMAT fmt, bool is_weak) :
   is_weak_import_ = is_weak;
 }
 
+ChainedBindingInfo::~ChainedBindingInfo() {
+  clear();
+}
+
 ChainedBindingInfo& ChainedBindingInfo::operator=(ChainedBindingInfo other) {
   swap(other);
   return *this;


### PR DESCRIPTION
Fixes #1139 