### PR TITLE
fix build for vcpkg fmt-v11-join / missing #include <memory>

### DIFF
--- a/src/MachO/BuildVersion.cpp
+++ b/src/MachO/BuildVersion.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ranges.h>
 #include "LIEF/Visitor.hpp"
 
 #include "frozen.hpp"

--- a/src/MachO/DylibCommand.cpp
+++ b/src/MachO/DylibCommand.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "spdlog/fmt/fmt.h"
+#include "spdlog/fmt/ranges.h"
 #include "LIEF/utils.hpp"
 #include "LIEF/Visitor.hpp"
 

--- a/src/MachO/SourceVersion.cpp
+++ b/src/MachO/SourceVersion.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "spdlog/fmt/fmt.h"
+#include "spdlog/fmt/ranges.h"
 #include "LIEF/Visitor.hpp"
 
 #include "LIEF/MachO/SourceVersion.hpp"

--- a/src/MachO/VersionMin.cpp
+++ b/src/MachO/VersionMin.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "spdlog/fmt/fmt.h"
+#include "spdlog/fmt/ranges.h"
 #include "LIEF/Visitor.hpp"
 
 #include "LIEF/MachO/VersionMin.hpp"

--- a/src/PE/Header.cpp
+++ b/src/PE/Header.cpp
@@ -23,6 +23,7 @@
 #include "frozen.hpp"
 
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ranges.h>
 
 namespace LIEF {
 namespace PE {

--- a/src/PE/OptionalHeader.cpp
+++ b/src/PE/OptionalHeader.cpp
@@ -23,6 +23,7 @@
 #include "PE/Structures.hpp"
 
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ranges.h>
 
 namespace LIEF {
 namespace PE {

--- a/src/PE/TLS.cpp
+++ b/src/PE/TLS.cpp
@@ -21,6 +21,7 @@
 #include "PE/Structures.hpp"
 
 #include "spdlog/fmt/fmt.h"
+#include "spdlog/fmt/ranges.h"
 
 namespace LIEF {
 namespace PE {

--- a/src/internal_utils.hpp
+++ b/src/internal_utils.hpp
@@ -15,6 +15,7 @@
  */
 #ifndef LIEF_INTERNAL_UTILS_HEADER
 #define LIEF_INTERNAL_UTILS_HEADER
+#include <memory>
 #include <string>
 #include <vector>
 #include <set>
@@ -22,6 +23,7 @@
 #include <unordered_map>
 #include <sstream>
 #include "spdlog/fmt/fmt.h"
+#include "spdlog/fmt/ranges.h"
 
 #include "LIEF/span.hpp"
 #include "LIEF/errors.hpp"

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -24,6 +24,7 @@
 
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ranges.h>
 
 #define LIEF_TRACE(...) LIEF::logging::Logger::instance().trace(__VA_ARGS__)
 #define LIEF_DEBUG(...) LIEF::logging::Logger::instance().debug(__VA_ARGS__)


### PR DESCRIPTION
fix build issues related to fmt::v11::join
So I could remove [ports/lief/fix-fmt-v11-join.patch](https://github.com/microsoft/vcpkg/pull/42374/files#diff-932510655a9b0704aa1a93506afb7d2672f522418bc5fd7926700013b0dacbce) file in my PR to vcpkg.
https://stackoverflow.com/questions/78935510/no-member-named-join-in-namespace-fmt
https://github.com/userver-framework/userver/issues/689
Fix build issues related to Linux builds.
https://github.com/microsoft/vcpkg/pull/42374/files#diff-13e9d5cc5531aae7df78450e65739c673fb47a1a37bb97b8bdd221ff4a27ead2R16-R21
So I could remove this line that helps Linux to build.