### PR TITLE
MachO::Binary::extend_section fill gap by default

### DIFF
--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -25,6 +25,11 @@
 
   * Add support for |lief-macho-atom-info| command (``LC_ATOM_INFO``)
 
+:ELF:
+
+  * Fix issue when parsing the dynamic table with an invalid offset (bug found
+    by :github_user:`lebr0nli`)
+
 :Extended:
 
   * Fix issue in the Python bindings while trying to access ``lief.__LIEF_MAIN_COMMIT__``

--- a/include/LIEF/ELF/Parser.hpp
+++ b/include/LIEF/ELF/Parser.hpp
@@ -126,9 +126,9 @@ class LIEF_API Parser : public LIEF::Parser {
   template<typename ELF_T>
   LIEF_LOCAL ok_error_t parse_segments();
 
-  LIEF_LOCAL uint64_t get_dynamic_string_table() const;
+  LIEF_LOCAL uint64_t get_dynamic_string_table(BinaryStream* stream = nullptr) const;
 
-  LIEF_LOCAL result<uint64_t> get_dynamic_string_table_from_segments() const;
+  LIEF_LOCAL result<uint64_t> get_dynamic_string_table_from_segments(BinaryStream* stream = nullptr) const;
 
   LIEF_LOCAL uint64_t get_dynamic_string_table_from_sections() const;
 
@@ -158,7 +158,7 @@ class LIEF_API Parser : public LIEF::Parser {
   LIEF_LOCAL result<uint32_t> nb_dynsym_relocations() const;
 
   template<typename ELF_T>
-  LIEF_LOCAL ok_error_t parse_dynamic_entries(uint64_t offset, uint64_t size);
+  LIEF_LOCAL ok_error_t parse_dynamic_entries(BinaryStream& stream);
 
   template<typename ELF_T>
   LIEF_LOCAL ok_error_t parse_dynamic_symbols(uint64_t offset);

--- a/include/LIEF/MachO/Binary.hpp
+++ b/include/LIEF/MachO/Binary.hpp
@@ -411,8 +411,9 @@ class LIEF_API Binary : public LIEF::Binary  {
   bool extend_segment(const SegmentCommand& segment, size_t size);
 
   /// Extend the **content** of the given Section.
-  /// @note This method may create a gap between the current section and the next one, if `size`
-  ///       is not multiple of the maximum alignment of sections before the current one.
+  /// @note This method may extend the section more than `size` preventing creation a gap
+  ///       between the current section and the next one.
+  ///       This may happen trying to satisfy alignment requirement of sections.
   /// @note This method works only with sections that belong to the first segment.
   bool extend_section(Section& section, size_t size);
 

--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -126,10 +126,13 @@ ok_error_t Parser::parse_binary() {
 
       int64_t rel_offset = seg_dyn->virtual_address() - load_seg.virtual_address();
       assert(rel_offset >= 0);
-      span<const uint8_t> dynamic_content = load_seg.content().subspan(rel_offset);
-      SpanStream stream(dynamic_content);
-      stream.set_endian_swap(stream_->should_swap());
-      parse_dynamic_entries<ELF_T>(stream);
+      span<const uint8_t> seg_content = load_seg.content();
+      if (!seg_content.empty()) {
+        span<const uint8_t> dynamic_content = seg_content.subspan(rel_offset);
+        SpanStream stream(dynamic_content);
+        stream.set_endian_swap(stream_->should_swap());
+        parse_dynamic_entries<ELF_T>(stream);
+      }
     } else /* No PT_LOAD segment wrapping up the PT_DYNAMIC table */ {
       const Elf_Off offset = seg_dyn->file_offset();
       ScopedStream scoped(*stream_, offset);

--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -1306,7 +1306,7 @@ bool Binary::extend_section(Section& section, size_t size) {
   }
 
   // Extend the given `section`.
-  section.size(section.size() + size);
+  section.size(section.size() + shift_value);
 
   return true;
 }

--- a/tests/elf/test_parser.py
+++ b/tests/elf/test_parser.py
@@ -206,3 +206,10 @@ def test_ebpf_relocations():
     assert relocations[8].info == 1
     assert relocations[8].purpose == lief.ELF.Relocation.PURPOSE.OBJECT
     assert relocations[8].type == lief.ELF.Relocation.TYPE.BPF_64_NODYLD32
+
+
+def test_issue_dynamic_table():
+    elf = lief.ELF.parse(get_sample("ELF/issue_dynamic_table.elf"))
+    dyn_entries = list(elf.dynamic_entries)
+    assert len(dyn_entries) == 28
+    assert dyn_entries[0].name == "libselinux.so.1"


### PR DESCRIPTION
The previous implementation extended section by strictly requested amount, possibly creating a gap in case we needed to satisfy alignment requirements.

However, information about the size of the gap is lost, and not trivial to recover. This patch changes `extend_section` to extend section by more than requested to avoid creating the gap.