### PR TITLE
Add cstdio include

### DIFF
--- a/include/LIEF/DWARF/Scope.hpp
+++ b/include/LIEF/DWARF/Scope.hpp
@@ -15,6 +15,7 @@
 #ifndef LIEF_DWARF_SCOPE_H
 #define LIEF_DWARF_SCOPE_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/include/LIEF/ObjC/Method.hpp
+++ b/include/LIEF/ObjC/Method.hpp
@@ -16,6 +16,7 @@
 #define LIEF_OBJC_METHOD_H
 #include <LIEF/visibility.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/include/LIEF/PDB/PublicSymbol.hpp
+++ b/include/LIEF/PDB/PublicSymbol.hpp
@@ -14,6 +14,7 @@
  */
 #ifndef LIEF_PDB_PUBLIC_SYMBOL_H
 #define LIEF_PDB_PUBLIC_SYMBOL_H
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <ostream>

--- a/include/LIEF/PDB/types/Attribute.hpp
+++ b/include/LIEF/PDB/types/Attribute.hpp
@@ -17,6 +17,7 @@
 
 #include "LIEF/visibility.h"
 
+#include <cstdint>
 #include <string>
 #include <memory>
 

--- a/include/LIEF/PE/LoadConfigurations/VolatileMetadata.hpp
+++ b/include/LIEF/PE/LoadConfigurations/VolatileMetadata.hpp
@@ -15,6 +15,7 @@
  */
 #ifndef LIEF_PE_LOAD_CONFIGURATION_VOLATILE_METADATA_H
 #define LIEF_PE_LOAD_CONFIGURATION_VOLATILE_METADATA_H
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/include/LIEF/PE/Relocation.hpp
+++ b/include/LIEF/PE/Relocation.hpp
@@ -15,6 +15,7 @@
  */
 #ifndef LIEF_PE_RELOCATION_H
 #define LIEF_PE_RELOCATION_H
+#include <cstdint>
 #include <vector>
 #include <ostream>
 #include <memory>

--- a/include/LIEF/PE/signature/attributes/PKCS9AtSequenceNumber.hpp
+++ b/include/LIEF/PE/signature/attributes/PKCS9AtSequenceNumber.hpp
@@ -15,6 +15,7 @@
  */
 #ifndef LIEF_PE_ATTRIBUTES_PKCS9_AT_SEQUENCE_NUMBER_H
 #define LIEF_PE_ATTRIBUTES_PKCS9_AT_SEQUENCE_NUMBER_H
+#include <cstdint>
 
 #include "LIEF/visibility.h"
 #include "LIEF/PE/signature/Attribute.hpp"

--- a/include/LIEF/PE/signature/attributes/SpcRelaxedPeMarkerCheck.hpp
+++ b/include/LIEF/PE/signature/attributes/SpcRelaxedPeMarkerCheck.hpp
@@ -15,6 +15,7 @@
  */
 #ifndef LIEF_PE_ATTRIBUTES_SPC_RELAXED_PE_MARKER_CHECK_H
 #define LIEF_PE_ATTRIBUTES_SPC_RELAXED_PE_MARKER_CHECK_H
+#include <cstdint>
 
 #include "LIEF/visibility.h"
 #include "LIEF/PE/signature/Attribute.hpp"

--- a/src/MachO/TrieNode.hpp
+++ b/src/MachO/TrieNode.hpp
@@ -15,6 +15,7 @@
  */
 #ifndef LIEF_MACHO_TRIE_NODE_H_
 #define LIEF_MACHO_TRIE_NODE_H_
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>


### PR DESCRIPTION
This is needed for uintXX_t types, GCC-15 is defauling to C23 and will error about it.

e.g.

include/LIEF/PE/LoadConfigurations/VolatileMetadata.hpp:145:3: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'