### PR TITLE
Fix BinaryStream: Implement robust bounds check and fix warnings

### DIFF
--- a/include/LIEF/BinaryStream/BinaryStream.hpp
+++ b/include/LIEF/BinaryStream/BinaryStream.hpp
@@ -190,10 +190,7 @@ class LIEF_API BinaryStream {
     }
     // Even though offset + size < ... => offset < ...
     // the addition could overflow so it's worth checking both
-    const bool read_ok = pos_ <= size() && (pos_ + N) <= size()
-      /* Check for an overflow */
-      && (static_cast<int64_t>(pos_) >= 0 && static_cast<int64_t>(N) >= 0)
-      && (static_cast<int64_t>(pos_ + N) >= 0);
+    const bool read_ok = pos_ <= size() && N <= size() - pos_;
 
     if (!read_ok) {
       return make_error_code(lief_errors::read_error);


### PR DESCRIPTION
Replaces the bounds check in BinaryStream::peek_array and read_array with a version robust against unsigned
overflow when calculating pos_ + N.

The check '(pos_ + N) <= size()' is replaced by 'N <= size() - pos_' (combined with 'pos_ <= size()'). This form is safe
against unsigned overflow.

This change also removes redundant checks that caused -Wtype-limits warnings (tested on i586), as the robust
unsigned check supersedes them.

/usr/src/RPM/BUILD/liblief-0.17.0/include/LIEF/BinaryStream/BinaryStream.hpp: 195:38:
warning: comparison is always true due to limited range of data type [-Wtype-limits]
 195 |       && (static_cast<int64_t>(pos_) >= 0 && static_cast<int64_t>(N) >= 0)
     |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/usr/src/RPM/BUILD/liblief-0.17.0/include/LIEF/BinaryStream/BinaryStream.hpp:
196:42: warning: comparison is always true due to limited range of data type
[-Wtype-limits]
 196 |       && (static_cast<int64_t>(pos_ + N) >= 0);
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~