### PR TITLE
Basic support for packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,19 +113,7 @@ message(STATUS "CMAKE_CXX_IMPLICIT_LINK_LIBRARIES: ${CMAKE_CXX_IMPLICIT_LINK_LIB
 message(STATUS "CMAKE_SYSTEM_PROCESSOR:            ${CMAKE_SYSTEM_PROCESSOR}")
 message(STATUS "CMAKE_MSVC_RUNTIME_LIBRARY:        ${CMAKE_MSVC_RUNTIME_LIBRARY}")
 
-if(LIEF_INSTALL)
-  if(UNIX)
-    include(GNUInstallDirs)
-    set(CMAKE_INSTALL_LIBDIR "lib")
-  else()
-    set(CMAKE_INSTALL_LIBDIR      "lib")
-    set(CMAKE_INSTALL_DATADIR     "share")
-    set(CMAKE_INSTALL_INCLUDEDIR  "include")
-    set(CMAKE_INSTALL_BINDIR      "bin")
-    set(CMAKE_INSTALL_DATAROOTDIR "share")
-    message(STATUS "Setting installation destination to: ${CMAKE_INSTALL_PREFIX}")
-  endif()
-endif()
+include(GNUInstallDirs)
 
 # LIEF Source definition
 # ======================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,8 @@ if(LIEF_PROFILING)
 endif()
 
 set_target_properties(LIB_LIEF PROPERTIES
+                      VERSION "${LIEF_VERSION_MAJOR}.${LIEF_VERSION_MINOR}.${LIEF_VERSION_PATCH}"
+                      SOVERSION "${LIEF_VERSION_MAJOR}"
                       OUTPUT_NAME LIEF
                       EXPORT_NAME LIEF
                       CLEAN_DIRECT_OUTPUT 1)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -48,13 +48,13 @@ else()
       DIRECTORY
       ${CMAKE_CURRENT_BINARY_DIR}/doxygen/html/
       DESTINATION
-      share/LIEF/doc/doxygen
+      ${CMAKE_INSTALL_DOCDIR}/doxygen
       COMPONENT doc)
 
     install(
       DIRECTORY
       ${CMAKE_CURRENT_BINARY_DIR}/sphinx-doc/
       DESTINATION
-      share/LIEF/doc/sphinx
+      ${CMAKE_INSTALL_DOCDIR}/sphinx
       COMPONENT doc)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 if (LIEF_INSTALL)
   install(
     DIRECTORY cmake
-    DESTINATION share/LIEF/examples
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/LIEF/examples
     COMPONENT examples
   )
 endif()

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 if (LIEF_INSTALL)
   install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-    DESTINATION share/LIEF/examples/c
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/LIEF/examples/c
     COMPONENT examples
     FILES_MATCHING REGEX "(.*).(hpp|h|c)$"
   )

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -114,7 +114,7 @@ endforeach()
 if (LIEF_INSTALL)
   install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-    DESTINATION share/LIEF/examples/cpp
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/LIEF/examples/cpp
     COMPONENT examples
     FILES_MATCHING REGEX "(.*).(hpp|h|cpp)$"
   )


### PR DESCRIPTION
- Use `GNUInstallDirs` unconditionally
  - `CMAKE_INSTALL_*` variables must never be overwritten by the project since these are meant to be used by the packagers to define their standard
  - Even on windows systems, e.g. with vcpkg, using `GNUInstallDirs` has become a standard
- Include SOVERSION for the library