### PR TITLE
Gate Melkor build by option

### DIFF
--- a/cmake/LIEFOptions.cmake
+++ b/cmake/LIEFOptions.cmake
@@ -102,6 +102,8 @@ endif()
 cmake_dependent_option(LIEF_OPT_FROZEN_EXTERNAL "Use an external provided version of Frozen" OFF
                        "_LIEF_USE_FROZEN" OFF)
 
+option(LIEF_USE_MELKOR "Build Melkor for testing" ON)
+
 # This option enables the install target in the cmake
 option(LIEF_INSTALL "Generate the install target." ON)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LIEF_EXAMPLES_BINARY_DIR "${PROJECT_BINARY_DIR}/examples")
 
 # Fuzzing
 # =======
-if(UNIX AND NOT APPLE)
+if(LIEF_USE_MELKOR AND UNIX AND NOT APPLE)
   set(MELKOR_VERSION ac2495b) # From the fork: https://github.com/romainthomas/elf_fuzzer
   set(MELKOR_SHA256 SHA256=8cccc4ca5e05e305215cc74761413746b660b76f5869a563f52cec1f23d79f2e)
   set(MELKOR_URL "${THIRD_PARTY_DIRECTORY}/Melkor_ELF_Fuzzer-${MELKOR_VERSION}.zip" CACHE STRING "URL to the Melkor package")


### PR DESCRIPTION
Building Melkor fails on Fedora with the error
```
/usr/bin/ld: warning: enabling an executable stack because of -z execstack command line option
gcc -ggdb -Wall -DDEBUG templates/foo.c templates/libfoo.c -static -o templates/foo_static
gcc -ggdb -Wall -DDEBUG src/env3.c src/generators.c -o src/env3
/usr/bin/ld: cannot find -lc: No such file or directory
/usr/bin/ld: have you installed the static version of the c library ?
collect2: error: ld returned 1 exit status
```