### PR TITLE
Fixed issue with explicit constructor compilation when old (GCC 9.0) compiler used

### DIFF
--- a/src/BinaryStream/FileStream.cpp
+++ b/src/BinaryStream/FileStream.cpp
@@ -29,7 +29,7 @@ result<FileStream> FileStream::from_file(const std::string& file) {
   ifs.seekg(0, std::ios::end);
   const auto size = static_cast<uint64_t>(ifs.tellg());
   ifs.seekg(0, std::ios::beg);
-  return FileStream{std::move(ifs), size};
+  return result<FileStream>(tl::in_place, std::move(ifs), size);
 }
 
 


### PR DESCRIPTION
The issue occurs when using older compiler versions (for example, **gcc/g++ 9.0** in my case). I’m forced to stick with this version because it supports **C++17**, and on **Ubuntu 16.04** (the **oldest Ubuntu LTS** release) no newer compiler is available in the repositories.

The crux of the problem is that result<T> is an alias:

```
template<typename T>
using result = tl::expected<T, lief_errors>;
```

tl::expected requires an explicit constructor for the type T. In other words, we need to return a result<T> that’s constructed in place via T’s explicit constructor—without any copies or moves. The following construct:

```
return result<FileStream>(tl::in_place, std::move(ifs), size);
```

solves the problem.