### PR TITLE
Handle non-roman characters and extend OID To String support.

### DIFF
--- a/src/PE/signature/x509.cpp
+++ b/src/PE/signature/x509.cpp
@@ -103,13 +103,11 @@ int lief_mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *
         if( ret == 0 ) {
             ret = mbedtls_snprintf( p, n, "%s=", short_name );
         } else {
-            // Get the numeric OID string
+            // Get OID numeric string and return x509 friendly name or OID numeric string
             char oid_str[64] = {0};
             mbedtls_oid_get_numeric_string(oid_str, sizeof(oid_str), &name->oid);
-
-            // Use your friendly name mapping
-            const char* friendly = LIEF::PE::oid_to_string(oid_str);
-            ret = mbedtls_snprintf(p, n, "%s=", friendly);
+            const char* friendly_name = LIEF::PE::oid_to_string(oid_str);
+            ret = mbedtls_snprintf(p, n, "%s=", friendly_name);
         }
         MBEDTLS_X509_SAFE_SNPRINTF;
 

--- a/src/PE/signature/x509.cpp
+++ b/src/PE/signature/x509.cpp
@@ -122,7 +122,7 @@ int lief_mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *
                 out.push_back('\\');
             }
 
-            if( c < 32 || c >= 127 )
+            if( c < 32 )
               continue;
             //else s[i] = c;
             out.push_back(c);

--- a/src/PE/signature/x509.cpp
+++ b/src/PE/signature/x509.cpp
@@ -35,6 +35,7 @@
 #include "LIEF/PE/signature/x509.hpp"
 #include "LIEF/PE/signature/RsaInfo.hpp"
 #include "LIEF/PE/EnumToString.hpp"
+#include "LIEF/PE/signature/OIDToString.hpp"
 
 namespace {
   // Copy this function from mbedtls since it is not exported
@@ -99,10 +100,17 @@ int lief_mbedtls_x509_dn_gets( char *buf, size_t size, const mbedtls_x509_name *
 
         ret = mbedtls_oid_get_attr_short_name( &name->oid, &short_name );
 
-        if( ret == 0 )
+        if( ret == 0 ) {
             ret = mbedtls_snprintf( p, n, "%s=", short_name );
-        else
-            ret = mbedtls_snprintf( p, n, "\?\?=" );
+        } else {
+            // Get the numeric OID string
+            char oid_str[64] = {0};
+            mbedtls_oid_get_numeric_string(oid_str, sizeof(oid_str), &name->oid);
+
+            // Use your friendly name mapping
+            const char* friendly = LIEF::PE::oid_to_string(oid_str);
+            ret = mbedtls_snprintf(p, n, "%s=", friendly);
+        }
         MBEDTLS_X509_SAFE_SNPRINTF;
 
         std::string out;


### PR DESCRIPTION
Regarding this Issue: https://github.com/lief-project/LIEF/issues/1219

First issue:
Non-roman characters don't print because x509.cpp explicitly limits the printable characters to the range "32" to "127" 
https://github.com/lief-project/LIEF/blob/75e359bec0d70b6ae25e12c4c3ac54a32a622bdb/src/PE/signature/x509.cpp#L125

This pull request removes the upper limit. This works as expected, see example below.

Second issue:
Conversion of OID To String was dependent on "mbedtls_oid_get_attr_short_name" from mbedtls, in instances where a OID was not found in mbedtls, LIEF returned "??".

Instead of outputting "??", we use the `oid_to_string` method defined in `OIDToString.cpp` to supplement mbedtls's OID lookup table. If the OID is still not found, we return the OID Numeric string. 

Before the change:
`
serialNumber=91140802MADALQC44B, ??=CN, ??=Private Organization, C=CN, ST=, O=, CN=`

Result of DER parsing after change:
`serialNumber=91140802MADALQC44B, JURISDICTION_OF_INCORPORATION_C=CN, BUSINESS_CATEGORY=Private Organization, C=CN, ST=山西省, O=运城市盐湖区风颜商贸有限公司, CN=运城市盐湖区风颜商贸有限公司`

--------------------------
Please feel free to make any stylistic changes as desired, but it seems like this meets the objectives in a fairly straight forward way relying on your existing OIDToString mapping. 

Note: I compiled and tested locally against a small number of files. I didn't test it against malformed certificates that could have malicious content in the fields. (I don't know if that is a thing that exists or not.) 
