### PR TITLE
Add missing export Macros

### DIFF
--- a/include/LIEF/PE/LoadConfigurations/DynamicRelocation/DynamicFixupARM64X.hpp
+++ b/include/LIEF/PE/LoadConfigurations/DynamicRelocation/DynamicFixupARM64X.hpp
@@ -32,7 +32,7 @@ class LIEF_API DynamicFixupARM64X : public DynamicFixup {
     DELTA = 2,
   };
 
-  struct reloc_entry_t {
+  struct LIEF_API reloc_entry_t {
     /// RVA where the fixup takes place
     uint32_t rva = 0;
 

--- a/include/LIEF/PE/resources/ResourceDialog.hpp
+++ b/include/LIEF/PE/resources/ResourceDialog.hpp
@@ -151,7 +151,7 @@ class LIEF_API ResourceDialog : public Object {
   /// This class is inherited by the regular or extended dialog's item:
   /// - ResourceDialogRegular::Item
   /// - ResourceDialogExtended::Item
-  class Item {
+  class LIEF_API Item {
     public:
     Item() = default;
     Item(const Item&) = default;

--- a/include/LIEF/PE/resources/ResourceDialogExtended.hpp
+++ b/include/LIEF/PE/resources/ResourceDialogExtended.hpp
@@ -68,7 +68,7 @@ class LIEF_API ResourceDialogExtended : public ResourceDialog {
 
   /// Font information for the font to use for the text in the dialog box and
   /// its controls
-  struct font_t {
+  struct LIEF_API font_t {
     /// The point size of the font
     uint16_t point_size = 0;
 

--- a/include/LIEF/PE/resources/ResourceDialogRegular.hpp
+++ b/include/LIEF/PE/resources/ResourceDialogRegular.hpp
@@ -55,7 +55,7 @@ class LIEF_API ResourceDialogRegular : public ResourceDialog {
 
   /// This structure represents additional font information that might be
   /// embedded at the end of the DLGTEMPLATE stream
-  struct font_t {
+  struct LIEF_API font_t {
     uint16_t point_size = 0;
     std::u16string name;
 

--- a/include/LIEF/PE/resources/ResourceVersion.hpp
+++ b/include/LIEF/PE/resources/ResourceVersion.hpp
@@ -42,7 +42,7 @@ class LIEF_API ResourceVersion : public Object {
 
   /// This structure represents the `VS_FIXEDFILEINFO` structure defined
   /// in `verrsrc.h`.
-  struct fixed_file_info_t {
+  struct LIEF_API fixed_file_info_t {
     enum class VERSION_OS : uint32_t {
       /// The operating system for which the file was designed is unknown to the system.
       UNKNOWN = 0x00000000,


### PR DESCRIPTION
Needed to build the Python bindings with lief as a shared libary.
Problem encountered on Conda-Forge https://github.com/conda-forge/lief-feedstock/pull/62.
Addressed there in https://github.com/conda-forge/lief-feedstock/pull/63.
