### PR TITLE
Fix MinGW Build When Some Formats Are Disabled

### DIFF
--- a/src/Abstract/Header.cpp
+++ b/src/Abstract/Header.cpp
@@ -16,9 +16,15 @@
 #include "LIEF/Visitor.hpp"
 #include "LIEF/Abstract/Header.hpp"
 
+#if defined(LIEF_ELF_SUPPORT)
 #include "LIEF/ELF/Binary.hpp"
+#endif
+#if defined(LIEF_MACHO_SUPPORT)
 #include "LIEF/MachO/Binary.hpp"
+#endif
+#if defined(LIEF_PE_SUPPORT)
 #include "LIEF/PE/Binary.hpp"
+#endif
 
 #include <spdlog/fmt/fmt.h>
 
@@ -37,6 +43,7 @@ static constexpr auto ARRAY_MODES = {
   Header::MODES::BITS_64, Header::MODES::THUMB,
 };
 
+#if defined(LIEF_ELF_SUPPORT)
 Header Header::from(const ELF::Binary& elf) {
   if constexpr (!lief_elf_support) {
     return {};
@@ -131,7 +138,9 @@ Header Header::from(const ELF::Binary& elf) {
 
   return hdr;
 }
+#endif
 
+#if defined(LIEF_PE_SUPPORT)
 Header Header::from(const PE::Binary& pe) {
   if constexpr (!lief_pe_support) {
     return {};
@@ -195,7 +204,9 @@ Header Header::from(const PE::Binary& pe) {
   }
   return hdr;
 }
+#endif
 
+#if defined(LIEF_MACHO_SUPPORT)
 Header Header::from(const MachO::Binary& macho) {
   if constexpr (!lief_macho_support) {
     return {};
@@ -290,6 +301,7 @@ Header Header::from(const MachO::Binary& macho) {
 
   return hdr;
 }
+#endif
 
 std::vector<Header::MODES> Header::modes_list() const {
   std::vector<MODES> flags;

--- a/src/asm/asm.cpp
+++ b/src/asm/asm.cpp
@@ -49,7 +49,9 @@
 #include "LIEF/asm/powerpc/registers.hpp"
 
 #include "LIEF/Abstract/Binary.hpp"
+#if defined(LIEF_COFF_SUPPORT)
 #include "LIEF/COFF/Binary.hpp"
+#endif
 
 #include "internal_utils.hpp"
 #include "messages.hpp"
@@ -104,6 +106,7 @@ assembly::Engine* Binary::get_engine(uint64_t) const {
 }
 
 
+#if defined(LIEF_COFF_SUPPORT)
 namespace COFF {
 assembly::Engine* Binary::get_engine(uint64_t) const {
   return nullptr;
@@ -126,6 +129,7 @@ Binary::instructions_it Binary::disassemble(const uint8_t* /*buffer*/, size_t /*
   return make_empty_iterator<assembly::Instruction>();
 }
 }
+#endif
 
 namespace assembly {
 namespace details {


### PR DESCRIPTION
This fixes the build when compiling with MinGW-w64 with some binary formats disabled.

The compiler error was:
```
: && /home/connor/Documents/minecraft-pi-reborn/quasi-msys2/env/wrappers/win-clang++ -O3 -DNDEBUG  -s -Xlinker --no-undefined -shared -o dependencies/LIEF/src/Release/libLIEF.dll -Wl,--out-implib,dependencies/LIEF/src/Release/libLIEF.dll.a -Wl,--major-image-version,0,--minor-image-version,0 dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Object.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/endianness_support.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Visitor.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/errors.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/hash_stream.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/internal_utils.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/iostream.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/json_api.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/logging.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/paging.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/utils.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/range.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/visitors/hash.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/BinaryStream/ASN1Reader.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/BinaryStream/BinaryStream.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/BinaryStream/FileStream.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/BinaryStream/MemoryStream.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/BinaryStream/SpanStream.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/BinaryStream/VectorStream.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Binary.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Symbol.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Header.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Section.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Parser.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Relocation.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Function.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/hash.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/json_api.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/debug_info.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/platforms/android/version.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Binary.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Builder.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/endianness_support.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/DataHandler/Handler.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/DataHandler/Node.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/DynamicEntry.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/DynamicEntryArray.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/DynamicEntryFlags.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/DynamicEntryLibrary.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/DynamicEntryRpath.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/DynamicEntryRunPath.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/DynamicSharedObject.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/EnumToString.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/GnuHash.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Header.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Layout.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Note.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Parser.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/ProcessorFlags.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Relocation.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/RelocationSizes.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/RelocationStrings.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Section.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Segment.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/Symbol.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/SymbolVersion.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/SymbolVersionAux.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/SymbolVersionAuxRequirement.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/SymbolVersionDefinition.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/SymbolVersionRequirement.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/SysvHash.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/hash.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/utils.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/json_api.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/NoteAbi.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/AndroidIdent.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/NoteGnuProperty.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/QNXStack.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/core/CoreAuxv.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/core/CoreFile.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/core/CorePrPsInfo.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/core/CorePrStatus.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/core/CoreSigInfo.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/properties/AArch64Feature.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/properties/AArch64PAuth.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/properties/StackSize.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/properties/X86Feature.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ELF/NoteDetails/properties/X86ISA.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/DWARF/dwarf.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/PDB/pdb.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/ObjC/objc.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/dyld-shared-cache/dyldsc.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/asm/asm.cpp.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/aes.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/aesce.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/aesni.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/aria.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/asn1parse.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/asn1write.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/base64.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/bignum.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/bignum_core.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/bignum_mod.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/bignum_mod_raw.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/block_cipher.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/camellia.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ccm.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/chacha20.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/chachapoly.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/cipher.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/cipher_wrap.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/cmac.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/constant_time.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ctr_drbg.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/debug.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/des.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/dhm.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ecdh.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ecdsa.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ecjpake.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ecp.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ecp_curves.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ecp_curves_new.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/entropy.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/entropy_poll.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/error.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/gcm.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/hkdf.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/hmac_drbg.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/lmots.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/lms.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/md.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/md5.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/memory_buffer_alloc.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/mps_reader.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/mps_trace.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/net_sockets.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/nist_kw.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/oid.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/padlock.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/pem.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/pk.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/pk_ecc.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/pk_wrap.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/pkcs12.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/pkcs5.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/pkcs7.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/pkparse.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/pkwrite.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/platform.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/platform_util.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/poly1305.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_aead.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_cipher.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_client.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_driver_wrappers_no_static.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_ecp.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_ffdh.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_hash.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_mac.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_pake.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_rsa.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_se.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_slot_management.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_crypto_storage.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_its_file.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/psa_util.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ripemd160.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/rsa.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/rsa_alt_helpers.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/sha1.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/sha256.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/sha3.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/sha512.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_cache.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_ciphersuites.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_client.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_cookie.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_debug_helpers_generated.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_msg.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_ticket.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_tls.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_tls12_client.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_tls12_server.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_tls13_client.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_tls13_generic.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_tls13_keys.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/ssl_tls13_server.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/threading.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/timing.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/version.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/version_features.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/x509.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/x509_create.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/x509_crl.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/x509_crt.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/x509_csr.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/x509write.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/x509write_crt.c.obj dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/mbed_src/library/x509write_csr.c.obj  -lws2_32  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && :
ld.lld: error: undefined symbol: LIEF::PE::ResourceStringTable::entry_t::key_u8[abi:cxx11]() const
>>> referenced by dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Header.cpp.obj:(LIEF::PE::ResourceStringTable::entry_t::to_string[abi:cxx11]() const)

ld.lld: error: undefined symbol: LIEF::PE::ResourceStringTable::entry_t::value_u8[abi:cxx11]() const
>>> referenced by dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Header.cpp.obj:(LIEF::PE::ResourceStringTable::entry_t::to_string[abi:cxx11]() const)

ld.lld: error: undefined symbol: LIEF::PE::ResourceVersion::fixed_file_info_t::to_string[abi:cxx11]() const
>>> referenced by dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Header.cpp.obj:(LIEF::PE::operator<<(std::ostream&, LIEF::PE::ResourceVersion::fixed_file_info_t const&))

ld.lld: error: undefined symbol: LIEF::PE::ResourcesManager::string_entry_t::string_u8[abi:cxx11]() const
>>> referenced by dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Header.cpp.obj:(LIEF::PE::operator<<(std::ostream&, LIEF::PE::ResourcesManager::string_entry_t const&))

ld.lld: error: undefined symbol: LIEF::COFF::Symbol::to_string[abi:cxx11]() const
>>> referenced by dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/Abstract/Header.cpp.obj:(LIEF::COFF::operator<<(std::ostream&, LIEF::COFF::Symbol const&))

ld.lld: error: undefined symbol: LIEF::COFF::Binary::to_string[abi:cxx11]() const
>>> referenced by dependencies/LIEF/src/CMakeFiles/LIB_LIEF.dir/Release/src/asm/asm.cpp.obj:(LIEF::COFF::operator<<(std::ostream&, LIEF::COFF::Binary const&))
clang++-20: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```