### PR TITLE
Ensure that added DYN ELF sections are properly aligned

### DIFF
--- a/include/LIEF/utils.hpp
+++ b/include/LIEF/utils.hpp
@@ -47,6 +47,10 @@ inline uint64_t align_down(uint64_t value, uint64_t align_on) {
   return value;
 }
 
+inline uint64_t align_with_offset(uint64_t value, uint64_t align_on, uint64_t offset) {
+  return align(value - offset, align_on) + offset;
+}
+
 template<typename T>
 inline constexpr T round(T x) {
   return static_cast<T>(round<uint64_t>(x));

--- a/src/ELF/Binary.tcc
+++ b/src/ELF/Binary.tcc
@@ -594,11 +594,14 @@ Segment* Binary::add_segment<Header::FILE_TYPE::DYN>(const Segment& segment, uin
 
   init_alignment(*this, *new_segment, ptr_size);
 
+  // We attempt to carry over the in-page offset for purpose of code or data alignment.
+  const uint64_t in_page_offset       = segment.file_offset() % psize;
+
   const uint64_t last_offset_segments = last_offset_segment();
   const uint64_t last_offset          = last_offset_segments;
-  const uint64_t last_offset_aligned  = align(last_offset, 0x10);
+  const uint64_t last_offset_aligned  = align_with_offset(last_offset, psize, in_page_offset);
   if (base == 0) {
-    base = align(next_virtual_address(), psize);
+    base = align(next_virtual_address(), new_segment->alignment());
   }
 
   uint64_t segmentsize = align(content.size(), 0x10);


### PR DESCRIPTION
The in-page offset from the source segment is now kept, since changing it may change the semantics of certain types of contents (e.g. ARM64 executable code relying on ADRP instructions).

Additionally, the virtual address of a segment is now properly aligned in accordance with p_align instead of being hardcoded at the page size.

Fixes: d717340c9 ("Improve the logic of sections insertion in ELF binaries")