### PR TITLE
Fix address type

### DIFF
--- a/src/PE/Builder.tcc
+++ b/src/PE/Builder.tcc
@@ -356,7 +356,7 @@ ok_error_t Builder::build_tls() {
       tls->addressof_callbacks(0);
     } else {
       binary_->patch_address(tls_callbacks_start, tls_data_.callbacks,
-                             Binary::VA_TYPES::VA);
+                             Binary::VA_TYPES::RVA);
     }
   }
 


### PR DESCRIPTION
The `build_tls` function uses the wrong address type when calling `patch_address`, which results in an error: `Can't find section with the rva: 0xfffffffec043e788` (large negative number)