### PR TITLE
Fix `MachO::Binary::virtual_address_to_offset()` for non-file-backed segment

### DIFF
--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -1842,7 +1842,9 @@ std::vector<uint8_t> Binary::raw() {
 
 result<uint64_t> Binary::virtual_address_to_offset(uint64_t virtual_address) const {
   const SegmentCommand* segment = segment_from_virtual_address(virtual_address);
-  if (segment == nullptr) {
+  // file_size() is 0 if segment is not file-backed, e.g. a `__DATA` segment that only has
+  // a ZEROFILL section.  In such case, there is no file offset available.
+  if (segment == nullptr || segment->file_size() == 0) {
     return make_error_code(lief_errors::conversion_error);
   }
   const uint64_t base_address = segment->virtual_address() - segment->file_offset();

--- a/tests/macho/test_generic.py
+++ b/tests/macho/test_generic.py
@@ -367,3 +367,15 @@ def test_resolve_function():
 
     macho = lief.MachO.parse(get_sample("MachO/RNCryptor.bin")).at(0)
     assert macho.get_function_address("_RNCryptorVersionString") == 0x00012988
+
+def test_virtual_address_to_offset_bss():
+    # c.f. https://github.com/lief-project/LIEF/issues/1299
+    macho = lief.MachO.parse(get_sample("MachO/do_add.bin")).at(0)
+
+    data_segment = macho.get_segment("__DATA")
+    assert data_segment.virtual_address == 0x100008000
+    # Contains only `__bss` section (S_ZEROFILL); thus no backing storage
+    assert data_segment.file_size == 0
+
+    offset = macho.virtual_address_to_offset(data_segment.virtual_address)
+    assert offset is lief.lief_errors.conversion_error


### PR DESCRIPTION
`LIEF::MachO::Binary::virtual_address_to_offset()` returns an incorrect result if the provided virtual address lies in a non-file-backed segment, e.g. a `__DATA` segment consisting only of `S_ZEROFILL` sections.

It turns out that the `MachO/do_add.bin` already serves as a demonstrator.  This executable file has a `__DATA` segment comprised of only the `_bss` section (which is `S_ZEROFILL`).  E.g. calling `LIEF::MachO::Binary::virtual_address_to_offset(0x100008008)` (which points to start of the `__DATA` segment), returns 8.  Instead, `virtual_address_to_offset()` should return `lief_errors::conversion_error`.

This pull request fixes #1299.