### PR TITLE
Fix `LIEF::MachO::Binary::patch_relocation()` for tagged pointers

### DIFF
--- a/src/MachO/Binary.tcc
+++ b/src/MachO/Binary.tcc
@@ -104,7 +104,7 @@ ok_error_t Binary::patch_relocation(Relocation& relocation, uint64_t from, uint6
   }
 
   auto* ptr_value = reinterpret_cast<T*>(segment_content.data() + relative_offset);
-  if (*ptr_value >= from && is_valid_addr(*ptr_value)) {
+  if (*ptr_value >= from) {
     *ptr_value += shift;
   }
   return ok();


### PR DESCRIPTION
`LIEF::MachO::Binary::shift()` does not update some dyld_info relocations.  Specifically, some Mach-O binaries may store relocation target values that are out of the VA range.
Apparently, this may be due to Armv8-A Address Translation, Section 5.1 Virtual address tagging, TBI (i.e. pointer tagging using the eight most significant bits).

Therefore, we may have [1] [2], e.g.
```bash
$ dyld_info -fixups tests/dl_samples/MachO/libmamba.4.0.1.dylib | grep 0x8000
    __DATA_CONST    __const        0x0032B020        rebase  0x8000000000305D78
    __DATA_CONST    __const        0x0032B230        rebase  0x800000000030D7F9
...
```
[1] `MachO/libmamba.4.0.1.dylib` is part of the LIEF public test fixtures
[2] Note the 0x8... (i.e., MSb is set)

The [current implementation](https://github.com/lief-project/LIEF/blob/main/src/MachO/Binary.tcc#L107) of `patch_relocation()`, calls `is_valid_ptr()`, which will return false because the pointer lies out of the VA range.

All the relocations must be fixed on `shift()`.  Similarly to what happens in [shift_command()](https://github.com/lief-project/LIEF/blob/main/src/MachO/Binary.cpp#L806) if the MachO image is using DyldChainedFixups instead, this should happen regardless of whether the value is outside of the VA range.

Fixes #1300.