### PR TITLE
Fix PE import parsing hang on malformed IAT

### DIFF
--- a/include/LIEF/PE/Parser.hpp
+++ b/include/LIEF/PE/Parser.hpp
@@ -57,6 +57,13 @@ class LIEF_API Parser : public LIEF::Parser {
 
   static constexpr size_t MAX_TLS_CALLBACKS = 3000;
 
+  // Bounds the import thunk loop to prevent hangs on malformed IATs
+  static constexpr size_t MAX_IMPORT_ENTRIES = 0x10000;
+
+  // Bounds peek_string_at to prevent multi-megabyte reads on invalid RVAs
+  // According to https://stackoverflow.com/a/23340781
+  static constexpr size_t MAX_IMPORT_NAME_SIZE = 0x1000;
+
   // According to https://stackoverflow.com/a/265782/87207
   static constexpr size_t MAX_DLL_NAME_SIZE = 255;
 

--- a/src/PE/Parser.cpp
+++ b/src/PE/Parser.cpp
@@ -1246,10 +1246,7 @@ std::unique_ptr<Binary> Parser::parse(std::unique_ptr<BinaryStream> stream,
 
 bool Parser::is_valid_import_name(const std::string& name) {
 
-  // According to https://stackoverflow.com/a/23340781
-  static constexpr unsigned MAX_IMPORT_NAME_SIZE = 0x1000;
-
-  if (name.empty() || name.size() > MAX_IMPORT_NAME_SIZE) {
+  if (name.empty() || name.size() > Parser::MAX_IMPORT_NAME_SIZE) {
     return false;
   }
   const bool valid_chars = std::all_of(std::begin(name), std::end(name),

--- a/src/PE/Parser.tcc
+++ b/src/PE/Parser.tcc
@@ -407,7 +407,7 @@ ok_error_t Parser::parse_import_table() {
 
     size_t idx = 0;
 
-    while (table != 0 || IAT != 0) {
+    while ((table != 0 || IAT != 0) && idx < Parser::MAX_IMPORT_ENTRIES) {
       auto entry = std::make_unique<ImportEntry>();
       entry->iat_value_ = IAT;
       entry->ilt_value_ = table;
@@ -420,7 +420,7 @@ ok_error_t Parser::parse_import_table() {
       if (!entry->is_ordinal()) {
         const size_t hint_off = binary_->rva_to_offset(entry->hint_name_rva());
         const size_t name_off = hint_off + sizeof(uint16_t);
-        if (auto entry_name = stream_->peek_string_at(name_off)) {
+        if (auto entry_name = stream_->peek_string_at(name_off, Parser::MAX_IMPORT_NAME_SIZE)) {
           entry->name_ = std::move(*entry_name);
         } else {
           LIEF_ERR("Can't read import entry name");
@@ -468,6 +468,12 @@ ok_error_t Parser::parse_import_table() {
         table = 0;
       }
     }
+
+    if (idx >= Parser::MAX_IMPORT_ENTRIES) {
+      LIEF_WARN("Import '{}' exceeded max entries ({}), IAT may lack null terminator",
+                import->name(), Parser::MAX_IMPORT_ENTRIES);
+    }
+
     import->nb_original_func_ = import->entries_.size();
     binary_->imports_.push_back(std::move(import));
   }


### PR DESCRIPTION
lief.PE.parse() hangs indefinitely on PEs with unterminated IATs.

The import thunk loop in Parser.tcc has no iteration limit, and peek_string_at() is called with no max length. A malformed PE causes hundreds of thousands of fake entries, each triggering multi-megabyte string reads.

This PR adds:
- MAX_IMPORT_ENTRIES (0x10000) to cap the thunk loop
- MAX_IMPORT_NAME_SIZE (0x1000) passed to peek_string_at() to bound each read
- A warning when truncation occurs

Follows the existing pattern used by MAX_TLS_CALLBACKS and MAX_RELOCATION_ENTRIES.
Tested against 0.16.7 and 0.17.5.

A POC generator script is attached. Run `python generate_poc.py` to produce `lief_hang_poc.exe`, `then lief.PE.parse("lief_hang_poc.exe")` to trigger the hang on an unpatched build.
[generate_poc.py](https://github.com/user-attachments/files/25891406/generate_poc.py)
