### PR TITLE
doc/sphinx/tutorials/12_elf_coredump.rst: Fix typo

### DIFF
--- a/doc/sphinx/tutorials/12_elf_coredump.rst
+++ b/doc/sphinx/tutorials/12_elf_coredump.rst
@@ -56,7 +56,7 @@ special note :class:`lief.ELF.CoreFile`:
 
 .. code-block:: python
 
-   nt_core_file = core.get(lief.ELF.Note.TYPE.CORE.FILE)
+   nt_core_file = core.get(lief.ELF.Note.TYPE.CORE_FILE)
 
 ELF notes are represented via the main :class:`lief.ELF.Note` interface. Some
 notes, such as :class:`lief.ELF.CoreFile`, expose additional APIs by extending


### PR DESCRIPTION
Tried to use the code from the docs, according to https://lief.re/doc/latest/formats/elf/python.html#lief.ELF.Note it should be CORE_FILE rather than CORE.FILE though.

Happens to the best of us.