### PR TITLE
Fix ELF note section corruption

### DIFF
--- a/src/ELF/Binary.tcc
+++ b/src/ELF/Binary.tcc
@@ -635,8 +635,7 @@ Segment* Binary::add_segment<Header::FILE_TYPE::DYN>(const Segment& segment,
                                         ptr_size));
   }
 
-  auto alloc =
-      datahandler_->make_hole(last_offset_aligned, new_segment->physical_size());
+  auto alloc = datahandler_->make_hole(last_offset, delta);
 
   if (!alloc) {
     LIEF_ERR("Allocation failed");

--- a/tests/elf/test_1326.py
+++ b/tests/elf/test_1326.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import lief
+import os
+import subprocess
+from pathlib import Path
+from subprocess import Popen
+def generate_elf_with_stapsdt():
+    TMP = Path("/tmp")
+    SOURCE = (TMP / "elf-note-stapsdt.c")
+    ELF = (TMP / "elf-note-stapsdt")
+    CC = os.getenv("CC", "/usr/bin/cc")
+    if not os.path.exists(CC):
+        raise RuntimeError("Unable to find a compiler")
+    CODE = r"""
+/*
+ * Simple C example with .note.stapsdt section for SystemTap SDT probes
+ *
+ * Dependency: sudo apt-get install systemtap-sdt-dev
+*/
+
+#include <stdio.h>
+#include <sys/sdt.h>
+
+int main(int argc, char **argv) {
+    int x = 42;
+    
+    printf("Hello, World!\n");
+    
+    // SystemTap SDT probe point
+    DTRACE_PROBE1(my_provider, my_probe1, argc);
+    DTRACE_PROBE1(my_provider, my_probe2, x);
+    
+    printf("x = %d, argc = %d\n", x, argc);
+
+    (void)argv;
+    
+    return 0;
+}
+"""
+    SOURCE.write_text(CODE)
+    cmd = [CC, "-o", str(ELF), str(SOURCE)]
+    lief.logging.info("Compile 'elf-note-stapsdt' with: {}".format(" ".join(cmd)))
+    with Popen(cmd, cwd=TMP, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as P:
+        assert P.stdout is not None
+        stdout = P.stdout.read()
+        lief.logging.info(stdout)
+        assert stdout == b""
+        return ELF
+
+def set_rpath(source, target, rpath):
+    elf = lief.ELF.parse(source)
+    existing = []
+    for entry in elf.dynamic_entries:
+        if entry.tag in [
+            lief.ELF.DynamicEntry.TAG.RPATH,
+            lief.ELF.DynamicEntry.TAG.RUNPATH,
+        ]:
+            existing.append(entry)
+    for entry in existing:
+        elf.remove(entry)
+    elf.add(lief.ELF.DynamicEntryRunPath(rpath))
+    elf.write(target)
+
+def show_notes(source):
+    elf = lief.ELF.parse(source)
+    for section in elf.sections:
+        if section.type == lief.ELF.Section.TYPE.NOTE and section.name == ".note.stapsdt":
+            print(f"  - NOTE: {section.name}, Size: {section.size}, Offset: 0x{section.offset:x}, VAddr: 0x{section.virtual_address:x}, Content: 0x{section.content[0]:x}...")
+            assert section.content[0] != 0
+def test_1326(count):
+    # Test for the issue https://github.com/lief-project/LIEF/issues/1326
+    sample = generate_elf_with_stapsdt()
+    source = str(sample)
+
+    print(f"ORIGINAL")
+    show_notes(source)
+    for round in range(count):
+        print(f"ROUND #{round+1}")
+        target = str(sample)+"."+str(round)
+        set_rpath(source, target, r"${ORIGIN}")
+        show_notes(source)
+        source = target
+    print()
+    print(f"ELF with .note.stapsdt survied {count} rounds")
+
+if __name__ == "__main__":
+    test_1326(10)

--- a/tests/elf/test_1326.py
+++ b/tests/elf/test_1326.py
@@ -1,88 +1,30 @@
 from pathlib import Path
 
 import lief
-import os
-import subprocess
-from pathlib import Path
-from subprocess import Popen
-def generate_elf_with_stapsdt():
-    TMP = Path("/tmp")
-    SOURCE = (TMP / "elf-note-stapsdt.c")
-    ELF = (TMP / "elf-note-stapsdt")
-    CC = os.getenv("CC", "/usr/bin/cc")
-    if not os.path.exists(CC):
-        raise RuntimeError("Unable to find a compiler")
-    CODE = r"""
-/*
- * Simple C example with .note.stapsdt section for SystemTap SDT probes
- *
- * Dependency: sudo apt-get install systemtap-sdt-dev
-*/
+import pytest
+from utils import check_layout, parse_elf
 
-#include <stdio.h>
-#include <sys/sdt.h>
 
-int main(int argc, char **argv) {
-    int x = 42;
-    
-    printf("Hello, World!\n");
-    
-    // SystemTap SDT probe point
-    DTRACE_PROBE1(my_provider, my_probe1, argc);
-    DTRACE_PROBE1(my_provider, my_probe2, x);
-    
-    printf("x = %d, argc = %d\n", x, argc);
+@pytest.mark.private
+def test_issue_1097(tmp_path: Path):
+    elf = parse_elf("private/ELF/kvrocks2redis")
+    check_layout(elf)
 
-    (void)argv;
-    
-    return 0;
-}
-"""
-    SOURCE.write_text(CODE)
-    cmd = [CC, "-o", str(ELF), str(SOURCE)]
-    lief.logging.info("Compile 'elf-note-stapsdt' with: {}".format(" ".join(cmd)))
-    with Popen(cmd, cwd=TMP, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as P:
-        assert P.stdout is not None
-        stdout = P.stdout.read()
-        lief.logging.info(stdout)
-        assert stdout == b""
-        return ELF
+    notes = elf.notes
+    assert len(notes) == 6
+    assert notes[5].name == "stapsdt"
 
-def set_rpath(source, target, rpath):
-    elf = lief.ELF.parse(source)
-    existing = []
-    for entry in elf.dynamic_entries:
-        if entry.tag in [
-            lief.ELF.DynamicEntry.TAG.RPATH,
-            lief.ELF.DynamicEntry.TAG.RUNPATH,
-        ]:
-            existing.append(entry)
-    for entry in existing:
-        elf.remove(entry)
-    elf.add(lief.ELF.DynamicEntryRunPath(rpath))
-    elf.write(target)
+    for n in elf.notes:
+        print(type(n))
 
-def show_notes(source):
-    elf = lief.ELF.parse(source)
-    for section in elf.sections:
-        if section.type == lief.ELF.Section.TYPE.NOTE and section.name == ".note.stapsdt":
-            print(f"  - NOTE: {section.name}, Size: {section.size}, Offset: 0x{section.offset:x}, VAddr: 0x{section.virtual_address:x}, Content: 0x{section.content[0]:x}...")
-            assert section.content[0] != 0
-def test_1326(count):
-    # Test for the issue https://github.com/lief-project/LIEF/issues/1326
-    sample = generate_elf_with_stapsdt()
-    source = str(sample)
+    config = lief.ELF.Builder.config_t()
+    config.force_relocate = True
 
-    print(f"ORIGINAL")
-    show_notes(source)
-    for round in range(count):
-        print(f"ROUND #{round+1}")
-        target = str(sample)+"."+str(round)
-        set_rpath(source, target, r"${ORIGIN}")
-        show_notes(source)
-        source = target
-    print()
-    print(f"ELF with .note.stapsdt survied {count} rounds")
+    out_path = tmp_path / "kvrocks2redis"
+    elf.write(out_path, config)
+    new_elf = parse_elf(out_path)
+    check_layout(new_elf)
 
-if __name__ == "__main__":
-    test_1326(10)
+    notes = new_elf.notes
+    assert len(notes) == 6
+    assert notes[5].name == "stapsdt"

--- a/tests/elf/test_1326.py
+++ b/tests/elf/test_1326.py
@@ -6,7 +6,7 @@ from utils import check_layout, parse_elf
 
 
 @pytest.mark.private
-def test_issue_1097(tmp_path: Path):
+def test_issue_1326(tmp_path: Path):
     elf = parse_elf("private/ELF/kvrocks2redis")
     check_layout(elf)
 


### PR DESCRIPTION
Here goes a potential fix for issue https://github.com/lief-project/LIEF/issues/1326, i. e., when lief-patchelf modifies the rpath of an ELF binary, the `.note.stapsdt` sections, which contain SystemTap probe descriptors, gets corrupted.

# Possible Explaination

in [Binary::add_segment<FILE_TYPE::DYN>()](https://github.com/lief-project/LIEF/blob/main/src/ELF/Binary.tcc#L585), there's an inconsistency between how section offsets are shifted and how the underlying data buffer is modified,

```c++
  uint64_t segmentsize = align(content.size(), 0x10);
  const uint64_t delta = last_offset_aligned + segmentsize - last_offset;

  shift_sections(last_offset, delta);
  // ...

  auto alloc =
      datahandler_->make_hole(last_offset_aligned, new_segment->physical_size());
```

[shift_sections(last_offset, delta)](https://github.com/lief-project/LIEF/blob/main/src/ELF/Binary.tcc#L621) shifts section offsets based on `last_offset` by `delta`, which includes alignment padding. [datahandler_->make_hole(last_offset_aligned, new_segment->physical_size())](https://github.com/lief-project/LIEF/blob/main/src/ELF/Binary.tcc#L638) inserts bytes at `last_offset_aligned`.

When the last segment doesn't end on a page boundary, `last_offset` and `last_offset_aligned` will be different. The offsets of the sections are shifted with paddings, and the data buffers are not. It may result in meaningless return value of Section::content(), similar to dangling pointers.

# Proposed Fix

Simply make the `datahandler_->make_hole` call coincide with `shift_sections`,

```c++
  auto alloc = datahandler_->make_hole(last_offset, delta);
```

# Tests

A sample c program with SystemTap SDT probes is provided in a python test script. LIEF 0.17.6 will fail with many logs from LIEF library, while the patched version will smoothly pass the test.

```console
$ pip3 freeze
lief==0.17.6
$ python3 tests/elf/test_1326.py
ORIGINAL
  - NOTE: .note.stapsdt, Size: 160, Offset: 0x3040, VAddr: 0x0, Content: 0x8...
ROUND #1
  - NOTE: .note.stapsdt, Size: 160, Offset: 0x3040, VAddr: 0x0, Content: 0x8...
ROUND #2
Note not parsed!
...
Too many errors while trying to parse notes
Note not parsed!
...
Too many errors while trying to parse notes
  - NOTE: .note.stapsdt, Size: 160, Offset: 0x50c0, VAddr: 0x0, Content: 0x0...
Traceback (most recent call last):
...
  File "/home/bpint/Downloads/own/tests/elf/test_1326.py", line 70, in show_notes
    assert section.content[0] != 0
           ^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

```console
$ pip3 freeze
lief @ file:///build/LIEF/api/python
$ python3 test/elf/test_1326.py
ORIGINAL
  - NOTE: .note.stapsdt, Size: 160, Offset: 0x3040, VAddr: 0x0, Content: 0x8...
ROUND #1
  - NOTE: .note.stapsdt, Size: 160, Offset: 0x3040, VAddr: 0x0, Content: 0x8...
...
ROUND #10
  - NOTE: .note.stapsdt, Size: 160, Offset: 0x50c0, VAddr: 0x0, Content: 0x8...

ELF with .note.stapsdt survied 10 rounds
```
