### PR TITLE
add #include <sstream> for gcc-17

### DIFF
--- a/include/LIEF/PE/ResourcesManager.hpp
+++ b/include/LIEF/PE/ResourcesManager.hpp
@@ -16,6 +16,7 @@
 #ifndef LIEF_PE_RESOURCES_MANAGER_H
 #define LIEF_PE_RESOURCES_MANAGER_H
 #include <ostream>
+#include <sstream>
 
 #include "LIEF/visibility.h"
 #include "LIEF/Object.hpp"


### PR DESCRIPTION
## add one #include <sstream> for gcc-17


**without patch:**

FAILED: [code=1] obj/deps/LIEF/src/PE/liblief.ResourcesManager.o 
x86_64-pc-linux-gnu-g++ -MMD -MF obj/deps/LIEF/src/PE/liblief.ResourcesManager.o.d -D_GLIBCXX_USE_CXX11_ABI=1 -D_FILE_OFFSET_BITS=64 -DNODE_OPENSSL_CONF_NAME=nodejs_conf -DNODE_OPENSSL_CERT_STORE -DICU_NO_USER_DATA_OVERRIDE -D__STDC_FORMAT_MACROS -DLIEF_STATIC '-DMBEDTLS_CONFIG_FILE="config/mbedtls/config.h"' -DMBEDTLS_NO_PLATFORM_ENTROPY -DSPDLOG_DISABLE_DEFAULT_LOGGER -DSPDLOG_NO_EXCEPTIONS '-DSPDLOG_FUNCTION=""' -DNDEBUG -I../../deps/LIEF -I../../deps/LIEF/include -I../../deps/LIEF/src -I../../deps/LIEF/third-party/mbedtls/include -I../../deps/LIEF/third-party/mbedtls/library -I../../deps/LIEF/third-party/spdlog/include -I../../deps/LIEF/third-party/frozen/include -I../../deps/LIEF/include/LIEF/third-party -I../../deps/LIEF/include/LIEF/third-party/internal -pthread -Wall -Wextra -Wno-unused-parameter -fPIC -m64 -fno-omit-frame-pointer -march=native -O3 -mprefer-vector-width=512 -fno-vect-cost-model -pipe -Werror=lto-type-mismatch -Werror=odr -Werror=strict-aliasing -Wno-template-id-cdtor -fno-rtti -fno-exceptions -fno-strict-aliasing -std=gnu++20 -std=gnu++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -Wpedantic -Wno-expansion-to-defined -Werror=return-type -fno-exceptions  -c ../../deps/LIEF/src/PE/ResourcesManager.cpp -o obj/deps/LIEF/src/PE/liblief.ResourcesManager.o
In file included from ../../deps/LIEF/src/PE/ResourcesManager.cpp:20:
../../deps/LIEF/include/LIEF/PE/ResourcesManager.hpp:218:45: error: ‘std::ostringstream’ has not been declared
  218 |   void print_tree(const ResourceNode& node, std::ostringstream& stream,
      |                                             ^~~
../../deps/LIEF/include/LIEF/PE/ResourcesManager.hpp:30:1: note: ‘std::ostringstream’ is defined in header ‘<sstream>’; this is probably fixable by adding ‘#include <sstream>’
   29 | #include "LIEF/PE/resources/ResourceAccelerator.hpp"
  +++ |+#include <sstream>



**os-info**

sh bash 5.3_p15
ld GNU ld (Gentoo 2.46.1 p1) 2.46.1
app-misc/pax-utils:        1.3.10::gentoo
app-shells/bash:           5.3_p15::gentoo
dev-build/autoconf:        2.13-r9::gentoo, 2.73-r2::gentoo
dev-build/automake:        1.18.1-r1::gentoo
dev-build/cmake:           4.3.3::gentoo
dev-build/libtool:         2.5.4::gentoo
dev-build/make:            4.4.1-r102::gentoo
dev-build/meson:           1.11.1::gentoo
dev-lang/perl:             5.42.2::gentoo
dev-lang/python:           3.13.14::gentoo, 3.14.6::gentoo
dev-lang/rust:             1.94.1::gentoo, 1.95.0::gentoo
llvm-core/clang:           20.1.8::gentoo, 21.1.8::gentoo, 22.1.7::gentoo
llvm-core/llvm:            20.1.8::gentoo, 21.1.8::gentoo, 22.1.7::gentoo
sys-apps/baselayout:       2.18-r1::gentoo
sys-apps/openrc:           0.63.1::gentoo
sys-apps/sandbox:          2.49::gentoo
sys-devel/binutils:        2.46.1::gentoo
sys-devel/binutils-config: 5.6::gentoo
sys-devel/gcc:             11.5.0::gentoo, 12.5.0::gentoo, 13.4.1_p20260603::gentoo, 14.3.1_p20260604::gentoo, 15.3.0::gentoo, 16.1.1_p20260606::gentoo, 17.0.0_p20260607-r1::gentoo
sys-devel/gcc-config:      2.12.2::gentoo
sys-kernel/linux-headers:  6.19::gentoo (virtual/os-headers)
sys-libs/glibc:            2.43-r2::gentoo