### PR TITLE
doc: use get_function_address() in ELF transformation tutorial

### DIFF
--- a/doc/sphinx/tutorials/08_elf_bin2lib.rst
+++ b/doc/sphinx/tutorials/08_elf_bin2lib.rst
@@ -143,7 +143,8 @@ Now that we have identified the address, we can export it as a named function:
 
 .. code-block:: python
 
-  >>> crackme101.add_exported_function(0x72A, "check_found")
+  >>> addr = crackme101.get_function_address("check_found") # 0x72A
+  >>> crackme101.add_exported_function(addr, "check_found")
   >>> crackme101.write("libcrackme101.so")
 
 And that's all!


### PR DESCRIPTION
This is a QoL change in the tutorial, that will allow users to automatically retrieve the address of the function they want to export