### PR TITLE
Fix for setting soname

### DIFF
--- a/src/ELF/Symbol.cpp
+++ b/src/ELF/Symbol.cpp
@@ -87,16 +87,21 @@ std::string Symbol::demangled_name() const {
   } else {
 #if defined(__unix__)
     int status = 0;
-    const std::string& name = this->name().c_str();
+    const std::string& name = this->name();
+    if (name.rfind("_Z", 0) != 0) {
+      return name;
+    }
+
     char* demangled_name =
         abi::__cxa_demangle(name.c_str(), nullptr, nullptr, &status);
 
-    if (status == 0) {
+    if (status == 0 && demangled_name != nullptr) {
       std::string realname = demangled_name;
       free(demangled_name); // NOLINT(cppcoreguidelines-no-malloc)
       return realname;
     }
 
+    free(demangled_name); // NOLINT(cppcoreguidelines-no-malloc)
     return name;
 #else
     return "";


### PR DESCRIPTION
Problem observed processing libtcl8.6.so

abi::__cxa_demangle("Iso88591ToUtfProc")
LIEF::ELF::Symbol::demangled_name()
LIEF::to_string<LIEF::ELF::Symbol>()
LIEF::ELF::Binary::shift_symbols()
LIEF::ELF::Binary::relocate_phdr_table_pie()
LIEF::ELF::Builder::build()
LIEF::ELF::Binary::write()

Adding a SONAME forces LIEF to relayout the ELF enough to shift symbols. During debug formatting, LIEF tries to demangle Tcl’s plain C symbol Iso88591ToUtfProc, and FreeBSD’s demangler crashes.