### PR TITLE
Avoid crash with malformed symbols in debug printing

### DIFF
--- a/src/ELF/ExeLayout.hpp
+++ b/src/ELF/ExeLayout.hpp
@@ -394,7 +394,11 @@ class LIEF_LOCAL ExeLayout : public Layout {
     std::vector<uint32_t> hash_values(dynamic_symbols.size() - symndx, 0);
 
     for (size_t i = symndx; i < dynamic_symbols.size(); ++i) {
-      LIEF_DEBUG("Processing symbol {}", to_string(dynamic_symbols[i]));
+      // Avoid stringifying the symbol here: Symbol::operator<< demangles
+      // names, and this debug argument is evaluated even when debug logging
+      // is disabled.  The GNU hash rebuild only needs the raw symbol name.
+      // Causes a crash with QtCore-style malformed symbols.
+      LIEF_DEBUG("Processing symbol {}", dynamic_symbols[i].name());
       const uint32_t hash = dl_new_hash(dynamic_symbols[i].name().c_str());
       int bucket = hash % nb_buckets;
 


### PR DESCRIPTION
The debug argument is evaluated even when debug logging is disabled, and QtCore-style malformed symbols were causing a crash.