### PR TITLE
Optimize ELF data insertion when appending content

### DIFF
--- a/api/python/src/ELF/objects/pyBinary.cpp
+++ b/api/python/src/ELF/objects/pyBinary.cpp
@@ -853,6 +853,10 @@ void create<Binary>(nb::module_& m) {
       "array_tag"_a
     )
 
+    .def("reserve_segments",
+        &Binary::reserve_segments,
+        "count"_a)
+
     .def("find_version_requirement",
       nb::overload_cast<const std::string&>(&Binary::find_version_requirement),
       R"doc(

--- a/include/LIEF/ELF/Binary.hpp
+++ b/include/LIEF/ELF/Binary.hpp
@@ -1295,6 +1295,7 @@ class LIEF_API Binary : public LIEF::Binary {
   LIEF_LOCAL std::string shstrtab_name() const;
   LIEF_LOCAL Section* add_frame_section(const Section& sec) LIEF_LIFETIMEBOUND;
   LIEF_LOCAL Section* add_section(std::unique_ptr<Section> sec) LIEF_LIFETIMEBOUND;
+  LIEF_LOCAL Section* append_section(std::unique_ptr<Section> sec) LIEF_LIFETIMEBOUND;
 
   LIEF_LOCAL LIEF::Binary::functions_t tor_functions(DynamicEntry::TAG tag) const;
 

--- a/include/LIEF/ELF/Binary.hpp
+++ b/include/LIEF/ELF/Binary.hpp
@@ -64,6 +64,9 @@ class LIEF_API Binary : public LIEF::Binary {
   friend class Layout;
   friend class ObjectFileLayout;
 
+  static constexpr uint32_t MAX_REGULAR_PHDRS = 0xFFFE;
+  size_t reserved_user_segments_ = 9;
+
   public:
   using string_list_t = std::vector<std::string>;
 
@@ -1177,6 +1180,31 @@ class LIEF_API Binary : public LIEF::Binary {
 
   bool should_swap() const {
     return should_swap_;
+  }
+
+  /// Configure the number of user segments for which space is reserved when
+  /// relocating the program-header table with `PHDR_RELOC::BINARY_END`.
+  ///
+  /// This function must be called before the program-header table is relocated.
+  /// One additional entry is reserved internally for the `PT_LOAD` segment that
+  /// maps the relocated table.
+  ///
+  /// @param[in] count The number of segments to reserve
+  /// @return `false` if the reservation is zero, too large, or relocation has
+  ///         already occurred, and `true` otherwise.
+  bool reserve_segments(size_t count) {
+    if (count == 0 || phdr_reloc_info_.new_offset != 0) {
+      return false;
+    }
+
+    const uint64_t current = header_.numberof_segments();
+    if (current >= MAX_REGULAR_PHDRS ||
+        count > MAX_REGULAR_PHDRS - current - 1) {
+      return false;
+    }
+
+    reserved_user_segments_ = count;
+    return true;
   }
 
   protected:

--- a/include/LIEF/ELF/Binary.hpp
+++ b/include/LIEF/ELF/Binary.hpp
@@ -63,6 +63,8 @@ class LIEF_API Binary : public LIEF::Binary {
   friend class ExeLayout;
   friend class Layout;
   friend class ObjectFileLayout;
+  friend class Section;
+  friend class Segment;
 
   static constexpr uint32_t MAX_REGULAR_PHDRS = 0xFFFE;
   size_t reserved_user_segments_ = 9;
@@ -1212,6 +1214,12 @@ class LIEF_API Binary : public LIEF::Binary {
   }
 
   protected:
+  struct append_extent_cache_t {
+    uint64_t end = 0;
+    size_t contributors = 0;
+    bool valid = false;
+  };
+
   struct phdr_relocation_info_t {
     uint64_t new_offset = 0;
     size_t nb_segments = 0;
@@ -1290,6 +1298,18 @@ class LIEF_API Binary : public LIEF::Binary {
 
   LIEF_LOCAL LIEF::Binary::functions_t tor_functions(DynamicEntry::TAG tag) const;
 
+  LIEF_LOCAL void add_layout_extent(uint64_t end) noexcept;
+  LIEF_LOCAL void invalidate_append_file_end() noexcept;
+  LIEF_LOCAL bool append_file_end_valid() const noexcept;
+
+  LIEF_LOCAL void publish_layout(Section& section) noexcept;
+  LIEF_LOCAL void publish_layout(Segment& segment) noexcept;
+
+  LIEF_LOCAL void recompute_append_file_end() noexcept;
+  LIEF_LOCAL void update_layout_extent(
+    bool old_contributes, uint64_t old_offset, uint64_t old_size,
+    bool new_contributes, uint64_t new_offset, uint64_t new_size) noexcept;
+
   Header::CLASS type_ = Header::CLASS::NONE;
   Header header_;
   sections_t sections_;
@@ -1305,6 +1325,7 @@ class LIEF_API Binary : public LIEF::Binary {
   std::unique_ptr<GnuHash> gnu_hash_;
   std::unique_ptr<SysvHash> sysv_hash_;
   std::unique_ptr<DataHandler::Handler> datahandler_;
+  append_extent_cache_t append_extent_cache_;
   phdr_relocation_info_t phdr_reloc_info_;
 
   std::string interpreter_;

--- a/include/LIEF/ELF/Binary.hpp
+++ b/include/LIEF/ELF/Binary.hpp
@@ -211,6 +211,10 @@ class LIEF_API Binary : public LIEF::Binary {
   /// Iterator which outputs const Section& object
   using it_const_sections = const_ref_iterator<const sections_t&, const Section*>;
 
+  private:
+  void remove_section_by_ptr(Section* section, bool clear);
+  void remove_section_at(size_t index, bool clear);
+
   public:
   /**
    * This enum describes the different ways to relocate the segments table.

--- a/include/LIEF/ELF/Parser.hpp
+++ b/include/LIEF/ELF/Parser.hpp
@@ -49,7 +49,7 @@ class LIEF_API Parser : public LIEF::Parser {
   static constexpr uint32_t DELTA_NB_SYMBOLS = 3000;
   static constexpr uint32_t NB_MAX_BUCKETS = NB_MAX_SYMBOLS;
   static constexpr uint32_t NB_MAX_CHAINS = 1000000;
-  static constexpr uint32_t NB_MAX_SEGMENTS = 10000;
+  static constexpr uint32_t NB_MAX_SEGMENTS = 0xFFFE;
   static constexpr uint32_t NB_MAX_RELOCATIONS = 3000000;
   static constexpr uint32_t NB_MAX_DYNAMIC_ENTRIES = 1000;
   static constexpr uint32_t MAX_SEGMENT_SIZE = 3_GB;

--- a/include/LIEF/ELF/Section.hpp
+++ b/include/LIEF/ELF/Section.hpp
@@ -35,6 +35,7 @@ namespace ELF {
 
 namespace DataHandler {
 class Handler;
+class Node;
 }
 
 class Segment;
@@ -225,7 +226,7 @@ class LIEF_API Section : public LIEF::Section {
     type_{type} {}
 
   Section() = default;
-  ~Section() override = default;
+  ~Section() override;
 
   Section& operator=(Section other) {
     swap(other);
@@ -392,6 +393,16 @@ class LIEF_API Section : public LIEF::Section {
   LIEF_LOCAL Section(const T& header, ARCH arch);
 
   LIEF_LOCAL span<uint8_t> writable_content() LIEF_LIFETIMEBOUND;
+
+  LIEF_LOCAL void bind_node(DataHandler::Handler& handler,
+                            DataHandler::Node& node);
+
+  LIEF_LOCAL void release_node() noexcept;
+  LIEF_LOCAL void rebind_node_owner() noexcept;
+
+  static void invalidate_node_owner(void* owner,
+                                    DataHandler::Node& node) noexcept;
+
   ARCH arch_ = ARCH::NONE;
   TYPE type_ = TYPE::SHT_NULL_;
   uint64_t flags_ = 0;
@@ -402,7 +413,15 @@ class LIEF_API Section : public LIEF::Section {
   uint64_t entry_size_ = 0;
   segments_t segments_;
   bool is_frame_ = false;
+
+  /**
+   * Handler exclusively owns node_. The node stores a non-owning pointer to
+   * this section and clears both backreferences before it is destroyed.
+   * Copies are detached.
+   */
   DataHandler::Handler* datahandler_ = nullptr;
+  DataHandler::Node* node_ = nullptr;
+
   std::vector<uint8_t> content_c_;
 };
 

--- a/include/LIEF/ELF/Section.hpp
+++ b/include/LIEF/ELF/Section.hpp
@@ -321,9 +321,7 @@ class LIEF_API Section : public LIEF::Section {
   /// Remove the given ELF_SECTION_FLAGS
   void remove(FLAGS flag);
 
-  void type(TYPE type) {
-    type_ = type;
-  }
+  void type(TYPE type);
 
   void flags(uint64_t flags) {
     flags_ = flags;
@@ -361,10 +359,7 @@ class LIEF_API Section : public LIEF::Section {
     return segments_;
   }
 
-  Section& as_frame() LIEF_LIFETIMEBOUND {
-    is_frame_ = true;
-    return *this;
-  }
+  Section& as_frame() LIEF_LIFETIMEBOUND;
 
   bool is_frame() const {
     return is_frame_;
@@ -403,6 +398,12 @@ class LIEF_API Section : public LIEF::Section {
   static void invalidate_node_owner(void* owner,
                                     DataHandler::Node& node) noexcept;
 
+  LIEF_LOCAL void observe_layout(Binary& binary) noexcept;
+  LIEF_LOCAL void stop_observing_layout() noexcept;
+  LIEF_LOCAL void notify_layout_change(
+      bool old_contributes, uint64_t old_offset, uint64_t old_size,
+      bool new_contributes, uint64_t new_offset, uint64_t new_size) noexcept;
+
   ARCH arch_ = ARCH::NONE;
   TYPE type_ = TYPE::SHT_NULL_;
   uint64_t flags_ = 0;
@@ -413,6 +414,12 @@ class LIEF_API Section : public LIEF::Section {
   uint64_t entry_size_ = 0;
   segments_t segments_;
   bool is_frame_ = false;
+
+  /**
+   * Non-owning pointer to `Binary` whose section table contains this object.
+   * Copies and detached sections do not observe a layout.
+   */
+  Binary* layout_observer_ = nullptr;
 
   /**
    * Handler exclusively owns node_. The node stores a non-owning pointer to

--- a/include/LIEF/ELF/Segment.hpp
+++ b/include/LIEF/ELF/Segment.hpp
@@ -328,6 +328,12 @@ class LIEF_API Segment : public Object {
   static void invalidate_node_owner(void* owner,
                                     DataHandler::Node& node) noexcept;
 
+  LIEF_LOCAL void observe_layout(Binary& binary) noexcept;
+  LIEF_LOCAL void stop_observing_layout() noexcept;
+  LIEF_LOCAL void notify_layout_change(
+      bool old_contributes, uint64_t old_offset, uint64_t old_size,
+      bool new_contributes, uint64_t new_offset, uint64_t new_size) noexcept;
+
   TYPE type_ = TYPE::PT_NULL_;
   ARCH arch_ = ARCH::NONE;
   uint32_t flags_ = 0;
@@ -339,6 +345,12 @@ class LIEF_API Segment : public Object {
   uint64_t alignment_ = 0;
   uint64_t handler_size_ = 0;
   sections_t sections_;
+
+  /**
+   * Non-owning pointer to `Binary` whose segment table contains this object.
+   * Copies and detached segments do not observe a layout.
+   */
+  Binary* layout_observer_ = nullptr;
 
   /**
    * Handler exclusively owns node_. The node stores a non-owning pointer to

--- a/include/LIEF/ELF/Segment.hpp
+++ b/include/LIEF/ELF/Segment.hpp
@@ -38,6 +38,7 @@ class SpanStream;
 namespace ELF {
 namespace DataHandler {
 class Handler;
+class Node;
 }
 
 class Parser;
@@ -142,15 +143,14 @@ class LIEF_API Segment : public Object {
 
   Segment() = default;
 
-  ~Segment() override = default;
+  ~Segment() override;
 
   Segment& operator=(Segment other);
   Segment(const Segment& other);
 
-  Segment& operator=(Segment&&) = default;
-  Segment(Segment&&) = default;
+  Segment(Segment&& other) noexcept;
 
-  void swap(Segment& other);
+  void swap(Segment& other) noexcept;
 
   bool is_load() const {
     return type() == TYPE::LOAD;
@@ -319,6 +319,15 @@ class LIEF_API Segment : public Object {
   LIEF_LOCAL uint64_t handler_size() const;
   span<uint8_t> writable_content() LIEF_LIFETIMEBOUND;
 
+  LIEF_LOCAL void bind_node(DataHandler::Handler& handler,
+                            DataHandler::Node& node);
+
+  LIEF_LOCAL void release_node() noexcept;
+  LIEF_LOCAL void rebind_node_owner() noexcept;
+
+  static void invalidate_node_owner(void* owner,
+                                    DataHandler::Node& node) noexcept;
+
   TYPE type_ = TYPE::PT_NULL_;
   ARCH arch_ = ARCH::NONE;
   uint32_t flags_ = 0;
@@ -330,7 +339,15 @@ class LIEF_API Segment : public Object {
   uint64_t alignment_ = 0;
   uint64_t handler_size_ = 0;
   sections_t sections_;
+
+  /**
+   * Handler exclusively owns node_. The node stores a non-owning pointer to
+   * this segment and clears both backreferences before it is destroyed.
+   * Copies are detached.
+   */
   DataHandler::Handler* datahandler_ = nullptr;
+  DataHandler::Node* node_ = nullptr;
+
   std::vector<uint8_t> content_c_;
 };
 

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -191,7 +191,9 @@ void Binary::remove_section_at(size_t idx, bool clear) {
     return;
   }
 
+  invalidate_append_file_end();
   Section* s = sections_[idx].get();
+  s->stop_observing_layout();
 
   // Remove from segments:
   for (std::unique_ptr<Segment>& segment : segments_) {
@@ -1034,9 +1036,11 @@ Section* Binary::add(const Section& section, bool loaded, SEC_INSERT_POS pos) {
 
 Section* Binary::add_frame_section(const Section& sec) {
   auto new_section = std::make_unique<Section>(sec);
+  Section* section_ptr = new_section.get();
   this->header().numberof_sections(this->header().numberof_sections() + 1);
   this->sections_.push_back(std::move(new_section));
-  return this->sections_.back().get();
+  publish_layout(*section_ptr);
+  return section_ptr;
 }
 
 bool Binary::is_pie() const {
@@ -1187,6 +1191,9 @@ Segment* Binary::replace(const Segment& new_segment,
     (*it_segment_phdr)->clear();
   }
 
+  invalidate_append_file_end();
+  (*it_original_segment)->stop_observing_layout();
+
   // Remove
   std::unique_ptr<Segment> local_original_segment =
       std::move(*it_original_segment);
@@ -1199,7 +1206,9 @@ Segment* Binary::replace(const Segment& new_segment,
       new_segment_ptr->file_offset() + new_segment_ptr->physical_size();
   header.section_headers_offset(new_section_hdr_offset);
 
-  return segments_.emplace_back(std::move(new_segment_ptr)).get();
+  Segment* inserted = segments_.emplace_back(std::move(new_segment_ptr)).get();
+  publish_layout(*inserted);
+  return inserted;
 }
 
 
@@ -1214,6 +1223,10 @@ void Binary::remove(const Segment& segment, bool clear) {
     LIEF_ERR("Provided segment not found");
     return;
   }
+
+  invalidate_append_file_end();
+  Segment* segment_ptr = it_segment->get();
+  segment_ptr->stop_observing_layout();
 
   std::unique_ptr<Segment> local_segment = std::move(*it_segment);
 
@@ -1866,8 +1879,133 @@ void Binary::accept(LIEF::Visitor& visitor) const {
   visitor.visit(*this);
 }
 
+void Binary::add_layout_extent(uint64_t end) noexcept {
+  if (!append_file_end_valid()) {
+    return;
+  }
+
+  if (end > append_extent_cache_.end) {
+    append_extent_cache_.end = end;
+    append_extent_cache_.contributors = 1;
+  } else if (end == append_extent_cache_.end) {
+    ++append_extent_cache_.contributors;
+  }
+}
+
+void Binary::invalidate_append_file_end() noexcept {
+  append_extent_cache_ = {};
+}
+
+bool Binary::append_file_end_valid() const noexcept {
+  return append_extent_cache_.valid;
+}
+
+void Binary::publish_layout(Section& section) noexcept {
+  section.observe_layout(*this);
+
+  if (!append_file_end_valid() ||
+      section.is_frame() ||
+      section.type() == Section::TYPE::NOBITS) {
+    return;
+  }
+
+  add_layout_extent(section.file_offset() + section.size());
+}
+
+void Binary::publish_layout(Segment& segment) noexcept {
+  segment.observe_layout(*this);
+
+  if (!append_file_end_valid()) {
+    return;
+  }
+
+  add_layout_extent(segment.file_offset() + segment.physical_size());
+}
+
+void Binary::recompute_append_file_end() noexcept {
+  uint64_t maximum = 0;
+  size_t maximum_count = 0;
+
+  const auto account = [&maximum, &maximum_count](uint64_t end) {
+    if (end > maximum) {
+      maximum = end;
+      maximum_count = 1;
+    } else if (end == maximum) {
+      ++maximum_count;
+    }
+  };
+
+  for (const std::unique_ptr<Section>& section : sections_) {
+    if (section->is_frame() || section->type() == Section::TYPE::NOBITS) {
+      continue;
+    }
+
+    account(section->file_offset() + section->size());
+  }
+
+  for (const std::unique_ptr<Segment>& segment : segments_) {
+    account(segment->file_offset() + segment->physical_size());
+  }
+
+  append_extent_cache_.end = maximum;
+  append_extent_cache_.contributors = maximum_count;
+  append_extent_cache_.valid = true;
+}
+
+void Binary::update_layout_extent(
+    bool old_contributes, uint64_t old_offset, uint64_t old_size,
+    bool new_contributes, uint64_t new_offset, uint64_t new_size) noexcept {
+  if (!append_file_end_valid()) {
+    return;
+  }
+
+  const uint64_t old_end = old_offset + old_size;
+  const uint64_t new_end = new_offset + new_size;
+
+  uint64_t& maximum = append_extent_cache_.end;
+  size_t& maximum_count = append_extent_cache_.contributors;
+
+  bool removed_last_maximum = false;
+
+  if (old_contributes) {
+    if (old_end > maximum) {
+      invalidate_append_file_end();
+      return;
+    }
+
+    if (old_end == maximum) {
+      if (maximum_count == 0) {
+        invalidate_append_file_end();
+        return;
+      }
+
+      --maximum_count;
+      removed_last_maximum = maximum_count == 0;
+    }
+  }
+
+  if (new_contributes) {
+    if (new_end > maximum) {
+      maximum = new_end;
+      maximum_count = 1;
+      return;
+    }
+
+    if (new_end == maximum) {
+      ++maximum_count;
+      return;
+    }
+  }
+
+  // The next-largest extent is not known without a scan.
+  if (removed_last_maximum) {
+    invalidate_append_file_end();
+  }
+}
+
 void Binary::shift_sections(uint64_t from, uint64_t shift) {
   LIEF_DEBUG("[+] Shift Sections");
+  invalidate_append_file_end();
   for (std::unique_ptr<Section>& section : sections_) {
     if (section->is_frame()) {
       continue;
@@ -1886,6 +2024,8 @@ void Binary::shift_sections(uint64_t from, uint64_t shift) {
 void Binary::shift_segments(uint64_t from, uint64_t shift) {
 
   LIEF_DEBUG("Shifting segments by {:#x} from {:#x}", shift, from);
+
+  invalidate_append_file_end();
 
   for (std::unique_ptr<Segment>& segment : segments_) {
     if (segment->file_offset() >= from) {
@@ -2893,6 +3033,8 @@ uint64_t Binary::relocate_phdr_table_pie() {
   phdr_reloc_info_.new_offset = from;
   phdr_reloc_info_.nb_segments = shift / phdr_size - header_.numberof_segments();
 
+  invalidate_append_file_end();
+
   auto alloc = datahandler_->make_hole(from, shift);
   if (!alloc) {
     LIEF_ERR("Allocation failed");
@@ -2999,6 +3141,8 @@ uint64_t Binary::relocate_phdr_table_v3() {
     return 0;
   }
 
+  invalidate_append_file_end();
+
   // Add a segment that wraps this new PHDR
   auto phdr_load_segment = std::make_unique<Segment>();
   phdr_load_segment->type(Segment::TYPE::LOAD);
@@ -3014,6 +3158,8 @@ uint64_t Binary::relocate_phdr_table_v3() {
                              DataHandler::Node::SEGMENT};
   phdr_load_segment->bind_node(*datahandler_, datahandler_->add(new_node));
 
+  Segment* phdr_load_segment_ptr = phdr_load_segment.get();
+
   const auto it_new_place =
       std::find_if(segments_.rbegin(), segments_.rend(),
                    [](const auto& s) { return s->is_load(); });
@@ -3024,6 +3170,7 @@ uint64_t Binary::relocate_phdr_table_v3() {
     const size_t idx = std::distance(segments_.begin(), it_new_place.base());
     segments_.insert(segments_.begin() + idx, std::move(phdr_load_segment));
   }
+  publish_layout(*phdr_load_segment_ptr);
 
   header.numberof_segments(header.numberof_segments() + 1);
   phdr_reloc_info_.nb_segments = static_cast<size_t>(user_segments);
@@ -3155,6 +3302,9 @@ uint64_t Binary::relocate_phdr_table_v2() {
     LIEF_ERR("Allocation failed");
     return 0;
   }
+
+  invalidate_append_file_end();
+
   bss_segment->physical_size(bss_segment->virtual_size());
 
   // Create a LOAD segment that wraps the new location of the PT_PHDR.
@@ -3174,6 +3324,8 @@ uint64_t Binary::relocate_phdr_table_v2() {
 
   nsegment_addr->bind_node(*datahandler_, datahandler_->add(new_node));
 
+  Segment* new_segment_raw = new_segment_ptr.get();
+
   const auto it_new_segment_place =
       std::find_if(segments_.rbegin(), segments_.rend(),
                    [nsegment_addr](const std::unique_ptr<Segment>& s) {
@@ -3187,6 +3339,7 @@ uint64_t Binary::relocate_phdr_table_v2() {
         std::distance(segments_.begin(), it_new_segment_place.base());
     segments_.insert(segments_.begin() + idx, std::move(new_segment_ptr));
   }
+  publish_layout(*new_segment_raw);
 
   this->header().numberof_segments(this->header().numberof_segments() + 1);
 
@@ -3237,6 +3390,8 @@ uint64_t Binary::relocate_phdr_table_v1() {
   if (phdr_reloc_info_.new_offset > 0) {
     return phdr_reloc_info_.new_offset;
   }
+
+  invalidate_append_file_end();
 
   LIEF_DEBUG("Running v1 (gap) PHDR relocator");
 
@@ -3470,6 +3625,7 @@ Section* Binary::add_section(std::unique_ptr<Section> sec) {
     sec_ptr = sections_.insert(it_new_sec_place, std::move(sec))->get();
   }
 
+  publish_layout(*sec_ptr);
   return sec_ptr;
 }
 

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -180,15 +180,24 @@ void Binary::remove(const Section& section, bool clear) {
     return;
   }
 
-  size_t idx = std::distance(sections_.begin(), it_section);
+  remove_section_at(
+    static_cast<size_t>(std::distance(sections_.begin(), it_section)),
+    clear);
+}
 
-  Section* s = it_section->get();
+void Binary::remove_section_at(size_t idx, bool clear) {
+  if (idx >= sections_.size()) {
+    LIEF_WARN("Section index {} is out of range", idx);
+    return;
+  }
+
+  Section* s = sections_[idx].get();
 
   // Remove from segments:
   for (std::unique_ptr<Segment>& segment : segments_) {
     auto& sections = segment->sections_;
-    sections.erase(std::remove_if(sections.begin(), sections.end(),
-                                  [&s](const Section* sec) { return *sec == *s; }),
+
+    sections.erase(std::remove(sections.begin(), sections.end(), s),
                    sections.end());
   }
 
@@ -219,7 +228,28 @@ void Binary::remove(const Section& section, bool clear) {
     header().section_name_table_idx(header().section_name_table_idx() - 1);
   }
 
-  sections_.erase(it_section);
+  sections_.erase(sections_.begin() + static_cast<std::ptrdiff_t>(idx));
+}
+
+void Binary::remove_section_by_ptr(Section* section, bool clear) {
+  if (section == nullptr) {
+    return;
+  }
+
+  const auto it = std::find_if(
+    sections_.begin(), sections_.end(),
+    [section](const std::unique_ptr<Section>& candidate) {
+      return candidate.get() == section;
+    }
+  );
+
+  if (it == sections_.end()) {
+    LIEF_WARN("Section pointer is not owned by this binary");
+    return;
+  }
+
+  remove_section_at(static_cast<size_t>(std::distance(sections_.begin(), it)),
+                    clear);
 }
 
 void Binary::remove(const Note& note) {

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -3598,6 +3598,14 @@ bool Binary::is_targeting_android() const {
   return false;
 }
 
+Section* Binary::append_section(std::unique_ptr<Section> sec) {
+  Section* sec_ptr = sec.get();
+
+  sections_.emplace_back(std::move(sec));
+
+  publish_layout(*sec_ptr);
+  return sec_ptr;
+}
 
 Section* Binary::add_section(std::unique_ptr<Section> sec) {
   Section* sec_ptr = sec.get();

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -210,7 +210,7 @@ void Binary::remove(const Section& section, bool clear) {
   }
 
 
-  datahandler_->remove(s->file_offset(), s->size(), DataHandler::Node::SECTION);
+  s->release_node();
 
   // Patch header
   header().numberof_sections(header().numberof_sections() - 1);
@@ -1108,12 +1108,11 @@ Segment* Binary::replace(const Segment& new_segment,
   std::vector<uint8_t> content{content_ref.data(), content_ref.end()};
 
   auto new_segment_ptr = std::make_unique<Segment>(new_segment);
-  new_segment_ptr->datahandler_ = datahandler_.get();
 
   DataHandler::Node new_node{new_segment_ptr->file_offset(),
                              new_segment_ptr->physical_size(),
                              DataHandler::Node::SEGMENT};
-  datahandler_->add(new_node);
+  new_segment_ptr->bind_node(*datahandler_, datahandler_->add(new_node));
   new_segment_ptr->handler_size_ = new_segment_ptr->physical_size();
 
   const uint64_t last_offset_sections = last_offset_section();
@@ -1161,9 +1160,7 @@ Segment* Binary::replace(const Segment& new_segment,
   // Remove
   std::unique_ptr<Segment> local_original_segment =
       std::move(*it_original_segment);
-  datahandler_->remove(local_original_segment->file_offset(),
-                       local_original_segment->physical_size(),
-                       DataHandler::Node::SEGMENT);
+  local_original_segment->release_node();
   segments_.erase(it_original_segment);
 
   // Patch shdr
@@ -1194,8 +1191,7 @@ void Binary::remove(const Segment& segment, bool clear) {
     local_segment->clear();
   }
 
-  datahandler_->remove(local_segment->file_offset(),
-                       local_segment->physical_size(), DataHandler::Node::SEGMENT);
+  local_segment->release_node();
   if (phdr_reloc_info_.new_offset > 0) {
     ++phdr_reloc_info_.nb_segments;
   }
@@ -2983,11 +2979,10 @@ uint64_t Binary::relocate_phdr_table_v3() {
   phdr_load_segment->physical_address(phdr_load_segment->virtual_address());
   phdr_load_segment->alignment(0x1000);
   phdr_load_segment->add(Segment::FLAGS::R);
-  phdr_load_segment->datahandler_ = datahandler_.get();
 
   DataHandler::Node new_node{phdr_reloc_info_.new_offset, new_segtbl_sz,
                              DataHandler::Node::SEGMENT};
-  datahandler_->add(new_node);
+  phdr_load_segment->bind_node(*datahandler_, datahandler_->add(new_node));
 
   const auto it_new_place =
       std::find_if(segments_.rbegin(), segments_.rend(),
@@ -3143,12 +3138,11 @@ uint64_t Binary::relocate_phdr_table_v2() {
   nsegment_addr->flags(Segment::FLAGS::R);
   nsegment_addr->alignment(0x1000);
   nsegment_addr->file_offset(phdr_reloc_info_.new_offset);
-  nsegment_addr->datahandler_ = datahandler_.get();
 
   DataHandler::Node new_node{phdr_reloc_info_.new_offset, new_phdr_size,
                              DataHandler::Node::SEGMENT};
 
-  datahandler_->add(new_node);
+  nsegment_addr->bind_node(*datahandler_, datahandler_->add(new_node));
 
   const auto it_new_segment_place =
       std::find_if(segments_.rbegin(), segments_.rend(),

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -3606,6 +3606,7 @@ Section* Binary::add_section(std::unique_ptr<Section> sec) {
       std::find_if(sections_.begin(), sections_.end(),
                    [sec_ptr](const std::unique_ptr<Section>& S) {
                      return S->type() != Section::TYPE::NOBITS &&
+                            !S->is_frame() &&
                             S->file_offset() > sec_ptr->file_offset();
                    });
 

--- a/src/ELF/Binary.cpp
+++ b/src/ELF/Binary.cpp
@@ -2913,8 +2913,32 @@ uint64_t Binary::relocate_phdr_table_pie() {
  * strongly increase the final size of the binary.
  */
 uint64_t Binary::relocate_phdr_table_v3() {
-  // Reserve space for 10 user's segments
-  static constexpr size_t USER_SEGMENTS = 10;
+  static constexpr uint64_t INTERNAL_SEGMENTS = 1;
+
+  const uint64_t user_segments = reserved_user_segments_;
+
+  Header& header = this->header();
+
+  const uint64_t nb_segments = header.numberof_segments();
+  if (nb_segments >= MAX_REGULAR_PHDRS ||
+      user_segments > MAX_REGULAR_PHDRS - nb_segments - INTERNAL_SEGMENTS) {
+    LIEF_ERR("Can't reserve {} additional segments: the resulting PHDR count "
+             "would exceed {}", user_segments, MAX_REGULAR_PHDRS);
+    return 0;
+  }
+
+  const uint64_t reserved_phdr_entries = user_segments + INTERNAL_SEGMENTS;
+  const uint64_t total_phdr_entries = nb_segments + reserved_phdr_entries;
+  const uint64_t phdr_size = type() == Header::CLASS::ELF32 ?
+                                 sizeof(details::ELF32::Elf_Phdr) :
+                                 sizeof(details::ELF64::Elf_Phdr);
+
+  if (total_phdr_entries > std::numeric_limits<uint64_t>::max() / phdr_size) {
+    LIEF_ERR("Program-header table size overflow");
+    return 0;
+  }
+
+  const size_t new_segtbl_sz = total_phdr_entries * phdr_size;
 
   uint64_t last_off = 0;
   for (const std::unique_ptr<Segment>& segment : segments_) {
@@ -2930,20 +2954,12 @@ uint64_t Binary::relocate_phdr_table_v3() {
   }
 
   LIEF_DEBUG("Running v3 (file end) PHDR relocator");
-
-  Header& header = this->header();
-
-  const uint64_t phdr_size = type() == Header::CLASS::ELF32 ?
-                                 sizeof(details::ELF32::Elf_Phdr) :
-                                 sizeof(details::ELF64::Elf_Phdr);
   LIEF_DEBUG("Moving segment table at the end of the binary ({:#012x})",
              last_off_aligned);
 
   phdr_reloc_info_.new_offset = last_off_aligned;
   header.program_headers_offset(last_off_aligned);
 
-  const size_t new_segtbl_sz =
-      (header.numberof_segments() + USER_SEGMENTS) * phdr_size;
   const uint64_t delta = last_off_aligned - last_off + new_segtbl_sz;
   shift_sections(last_off, delta);
 
@@ -2985,7 +3001,7 @@ uint64_t Binary::relocate_phdr_table_v3() {
   }
 
   header.numberof_segments(header.numberof_segments() + 1);
-  phdr_reloc_info_.nb_segments = USER_SEGMENTS - /* For the PHDR LOAD */ 1;
+  phdr_reloc_info_.nb_segments = static_cast<size_t>(user_segments);
   return phdr_reloc_info_.new_offset;
 }
 

--- a/src/ELF/Binary.tcc
+++ b/src/ELF/Binary.tcc
@@ -509,12 +509,10 @@ Segment* Binary::add_segment<Header::FILE_TYPE::EXEC>(const Segment& segment,
   std::vector<uint8_t> content{content_ref.data(), content_ref.end()};
   auto new_segment = std::make_unique<Segment>(segment);
 
-  uint64_t last_offset_sections = last_offset_section();
-  uint64_t last_offset_segments = last_offset_segment();
-
-
-  uint64_t last_offset =
-      std::max<uint64_t>(last_offset_sections, last_offset_segments);
+  if (!append_file_end_valid()) {
+    recompute_append_file_end();
+  }
+  const uint64_t last_offset = append_extent_cache_.end;
 
   const auto psize = page_size();
   const uint64_t last_offset_aligned = align(last_offset, psize);
@@ -575,8 +573,11 @@ Segment* Binary::add_segment<Header::FILE_TYPE::EXEC>(const Segment& segment,
     seg_ptr =
         segments_.insert(segments_.begin() + idx, std::move(new_segment))->get();
   }
-  phdr_reloc_info_.nb_segments--;
   assert(seg_ptr != nullptr);
+
+  publish_layout(*seg_ptr);
+
+  phdr_reloc_info_.nb_segments--;
   return seg_ptr;
 }
 
@@ -673,6 +674,7 @@ Segment* Binary::add_segment<Header::FILE_TYPE::DYN>(const Segment& segment,
         segments_.insert(segments_.begin() + idx, std::move(new_segment))->get();
   }
   assert(seg_ptr != nullptr);
+  publish_layout(*seg_ptr);
   return seg_ptr;
 }
 

--- a/src/ELF/Binary.tcc
+++ b/src/ELF/Binary.tcc
@@ -522,11 +522,11 @@ Segment* Binary::add_segment<Header::FILE_TYPE::EXEC>(const Segment& segment,
 
   init_alignment(*this, *new_segment, this->ptr_size());
 
-  if (base == 0) {
-    base = align(next_virtual_address(), new_segment->alignment());
-  }
-
   if (segment.virtual_address() == 0) {
+    if (base == 0) {
+      base = align(next_virtual_address(), new_segment->alignment());
+    }
+
     new_segment->virtual_address(base + last_offset_aligned);
   }
 

--- a/src/ELF/Binary.tcc
+++ b/src/ELF/Binary.tcc
@@ -809,6 +809,14 @@ Section* Binary::add_section</*loaded=*/true>(const Section& section,
   segment_added->sections_.push_back(new_section.get());
 
   header().numberof_sections(header().numberof_sections() + 1);
+
+  // A loaded ET_EXEC section inherits the offset of a segment appended at the
+  // current file end. The generic add_section() search would therefore return
+  // sections_.end(), so append directly.
+  if (header().file_type() == Header::FILE_TYPE::EXEC) {
+    return append_section(std::move(new_section));
+  }
+
   return add_section(std::move(new_section));
 }
 

--- a/src/ELF/Binary.tcc
+++ b/src/ELF/Binary.tcc
@@ -539,16 +539,15 @@ Segment* Binary::add_segment<Header::FILE_TYPE::EXEC>(const Segment& segment,
   new_segment->physical_size(segmentsize);
   new_segment->virtual_size(segmentsize);
 
-  new_segment->datahandler_ = datahandler_.get();
-
   DataHandler::Node new_node{new_segment->file_offset(),
                              new_segment->physical_size(),
                              DataHandler::Node::SEGMENT};
-  datahandler_->add(new_node);
+  new_segment->bind_node(*datahandler_, datahandler_->add(new_node));
   auto alloc =
       datahandler_->make_hole(last_offset_aligned, new_segment->physical_size());
   if (!alloc) {
     LIEF_ERR("Allocation failed");
+    new_segment->release_node();
     return nullptr;
   }
   new_segment->content(content);
@@ -594,12 +593,11 @@ Segment* Binary::add_segment<Header::FILE_TYPE::DYN>(const Segment& segment,
   std::vector<uint8_t> content = as_vector(segment.content());
 
   auto new_segment = std::make_unique<Segment>(segment);
-  new_segment->datahandler_ = datahandler_.get();
 
   DataHandler::Node new_node{new_segment->file_offset(),
                              new_segment->physical_size(),
                              DataHandler::Node::SEGMENT};
-  datahandler_->add(new_node);
+  new_segment->bind_node(*datahandler_, datahandler_->add(new_node));
 
   init_alignment(*this, *new_segment, ptr_size);
 
@@ -650,6 +648,7 @@ Segment* Binary::add_segment<Header::FILE_TYPE::DYN>(const Segment& segment,
 
   if (!alloc) {
     LIEF_ERR("Allocation failed");
+    new_segment->release_node();
     return nullptr;
   }
 
@@ -794,11 +793,10 @@ Section* Binary::add_section</*loaded=*/true>(const Section& section,
              segment_added->virtual_address());
 
   auto new_section = std::make_unique<Section>(section);
-  new_section->datahandler_ = datahandler_.get();
 
   DataHandler::Node new_node{new_section->file_offset(), new_section->size(),
                              DataHandler::Node::SECTION};
-  datahandler_->add(new_node);
+  new_section->bind_node(*datahandler_, datahandler_->add(new_node));
 
   new_section->virtual_address(segment_added->virtual_address());
   new_section->size(segment_added->physical_size());
@@ -817,11 +815,10 @@ template<>
 Section* Binary::add_section</*loaded=*/false>(const Section& section,
                                                SEC_INSERT_POS pos) {
   auto new_section = std::make_unique<Section>(section);
-  new_section->datahandler_ = datahandler_.get();
 
   DataHandler::Node new_node{new_section->file_offset(), new_section->size(),
                              DataHandler::Node::SECTION};
-  datahandler_->add(new_node);
+  new_section->bind_node(*datahandler_, datahandler_->add(new_node));
 
   const uint64_t last_offset_sections = last_offset_section();
   const uint64_t last_offset_segments = last_offset_segment();
@@ -841,6 +838,7 @@ Section* Binary::add_section</*loaded=*/false>(const Section& section,
   auto alloc = datahandler_->make_hole(last_offset, section.size());
   if (!alloc) {
     LIEF_ERR("Allocation failed");
+    new_section->release_node();
     return nullptr;
   }
 

--- a/src/ELF/DataHandler/Handler.cpp
+++ b/src/ELF/DataHandler/Handler.cpp
@@ -28,6 +28,7 @@
 
 
 namespace LIEF::ELF::DataHandler {
+static constexpr uint64_t MAX_MEMORY_SIZE = 6_GB;
 
 class DataHandlerStream : public BinaryStream {
   public:
@@ -165,17 +166,33 @@ Node& Handler::add(const Node& node) {
 }
 
 ok_error_t Handler::make_hole(uint64_t offset, uint64_t size) {
-  auto res = reserve(offset, size);
-  if (!res) {
-    return res;
+  const auto current_size = static_cast<uint64_t>(data_.size());
+  const uint64_t base_size = offset >= current_size ? offset : current_size;
+
+  if (base_size > MAX_MEMORY_SIZE || size > MAX_MEMORY_SIZE - base_size) {
+    return make_error_code(lief_errors::corrupted);
   }
-  data_.insert(data_.begin() + offset, size, 0);
+
+  const uint64_t final_size = base_size + size;
+  if (final_size > static_cast<uint64_t>(data_.max_size())) {
+    return make_error_code(lief_errors::corrupted);
+  }
+
+  if (offset >= current_size) {
+    data_.resize(static_cast<size_t>(final_size), uint8_t{0});
+    return ok();
+  }
+
+  data_.insert(data_.begin() +
+               static_cast<std::vector<uint8_t>::difference_type>(offset),
+               static_cast<size_t>(size),
+               uint8_t{0});
+
   return ok();
 }
 
 
 ok_error_t Handler::reserve(uint64_t offset, uint64_t size) {
-  static constexpr auto MAX_MEMORY_SIZE = 6_GB;
   const auto full_size = static_cast<int64_t>(offset) + static_cast<int64_t>(size);
   if (full_size < 0) {
     return make_error_code(lief_errors::corrupted);

--- a/src/ELF/DataHandler/Handler.cpp
+++ b/src/ELF/DataHandler/Handler.cpp
@@ -111,19 +111,27 @@ bool Handler::has(uint64_t offset, uint64_t size, Node::Type type) {
   return it_node != nodes_.end();
 }
 
-result<Handler::ref_t<Node>> Handler::get(uint64_t offset, uint64_t size,
-                                          Node::Type type) {
-  Node tmp{offset, size, type};
+bool Handler::owns(const Node& node) const noexcept {
+  return std::any_of(
+    nodes_.begin(), nodes_.end(),
+    [&node](const std::unique_ptr<Node>& candidate) {
+      return candidate.get() == &node;
+    }
+  );
+}
 
+bool Handler::remove(Node& node) noexcept {
   const auto it_node = std::find_if(nodes_.begin(), nodes_.end(),
-                                    [&tmp](const std::unique_ptr<Node>& node) {
-                                      return tmp == *node;
+                                    [&node](const std::unique_ptr<Node>& cand) {
+                                      return cand.get() == &node;
                                     });
 
   if (it_node == nodes_.end()) {
-    return make_error_code(lief_errors::not_found);
+    return false;
   }
-  return **it_node;
+
+  nodes_.erase(it_node);
+  return true;
 }
 
 

--- a/src/ELF/DataHandler/Handler.hpp
+++ b/src/ELF/DataHandler/Handler.hpp
@@ -32,8 +32,6 @@ namespace ELF::DataHandler {
 
 class LIEF_API Handler {
   public:
-  template<class T>
-  using ref_t = std::reference_wrapper<T>;
 
   static constexpr size_t MAX_SIZE = 4_GB;
   Handler(std::vector<uint8_t> content) :
@@ -46,8 +44,10 @@ class LIEF_API Handler {
   Handler& operator=(const Handler&) = delete;
   Handler(const Handler&) = delete;
 
-  Handler& operator=(Handler&&) noexcept = default;
-  Handler(Handler&&) noexcept = default;
+  // Moving a Handler would invalidate handler pointers stored by attached
+  // sections and segments
+  Handler& operator=(Handler&&) noexcept = delete;
+  Handler(Handler&&) noexcept = delete;
 
   const std::vector<uint8_t>& content() const {
     return data_;
@@ -61,9 +61,11 @@ class LIEF_API Handler {
 
   bool has(uint64_t offset, uint64_t size, Node::Type type);
 
-  result<ref_t<Node>> get(uint64_t offset, uint64_t size, Node::Type type);
+  bool owns(const Node& node) const noexcept;
 
   Node& create(uint64_t offset, uint64_t size, Node::Type type);
+
+  bool remove(Node& node) noexcept;
 
   void remove(uint64_t offset, uint64_t size, Node::Type type);
 

--- a/src/ELF/DataHandler/Node.hpp
+++ b/src/ELF/DataHandler/Node.hpp
@@ -28,14 +28,29 @@ class LIEF_LOCAL Node {
     SECTION,
     SEGMENT,
   };
+  using owner_invalidator_t = void (*)(void* owner, Node& node) noexcept;
+
   Node() = default;
   Node(uint64_t offset, uint64_t size, Type type) :
     size_{size},
     offset_{offset},
     type_{type} {}
 
-  Node& operator=(const Node&) = default;
-  Node(const Node&) = default;
+  Node& operator=(const Node& other) noexcept {
+    if (this == &other) {
+      return *this;
+    }
+
+    size_ = other.size_;
+    offset_ = other.offset_;
+    type_ = other.type_;
+    return *this;
+  }
+
+  Node(const Node& other) noexcept :
+    size_{other.size_},
+    offset_{other.offset_},
+    type_{other.type_} {}
 
   uint64_t size() const {
     return size_;
@@ -60,6 +75,28 @@ class LIEF_LOCAL Node {
     offset_ = offset;
   }
 
+  void bind_owner(void* owner, owner_invalidator_t invalidator) noexcept {
+    assert(owner != nullptr);
+    assert(invalidator != nullptr);
+    assert(owner_ == nullptr);
+    assert(owner_invalidator_ == nullptr);
+
+    owner_ = owner;
+    owner_invalidator_ = invalidator;
+  }
+
+  void rebind_owner(void* owner) noexcept {
+    assert(owner != nullptr);
+    assert(owner_ != nullptr);
+    assert(owner_invalidator_ != nullptr);
+
+    owner_ = owner;
+  }
+
+  bool has_owner() const noexcept {
+    return owner_ != nullptr;
+  }
+
   bool operator==(const Node& rhs) const;
   bool operator!=(const Node& rhs) const {
     return !(*this == rhs);
@@ -74,12 +111,30 @@ class LIEF_LOCAL Node {
   bool operator>=(const Node& rhs) const {
     return (type() == rhs.type() && !(*this < rhs));
   }
-  ~Node() = default;
+  ~Node() {
+    invalidate_owner();
+  }
 
   private:
+  void invalidate_owner() noexcept {
+    void* owner = owner_;
+    owner_invalidator_t invalidator = owner_invalidator_;
+
+    // clear first to avoid callback recursion
+    owner_ = nullptr;
+    owner_invalidator_ = nullptr;
+
+    if (invalidator != nullptr) {
+      invalidator(owner, *this);
+    }
+  }
+
   uint64_t size_ = 0;
   uint64_t offset_ = 0;
   Type type_ = Type::UNKNOWN;
+
+  void* owner_ = nullptr;
+  owner_invalidator_t owner_invalidator_ = nullptr;
 };
 
 } // namespace LIEF::ELF::DataHandler

--- a/src/ELF/ExeLayout.hpp
+++ b/src/ELF/ExeLayout.hpp
@@ -967,14 +967,14 @@ class LIEF_LOCAL ExeLayout : public Layout {
 
       // Remove the current .shstrtab section
       Header& hdr = binary_->header();
-      if (hdr.section_name_table_idx() >= binary_->sections_.size()) {
+      const size_t shstr_idx = hdr.section_name_table_idx();
+      if (shstr_idx >= binary_->sections_.size()) {
         LIEF_ERR("Section names table index out of range");
         return make_error_code(lief_errors::file_format_error);
       }
-      std::unique_ptr<Section>& string_names_section =
-          binary_->sections_[hdr.section_name_table_idx()];
+
       std::string sec_name = binary_->shstrtab_name();
-      binary_->remove(*string_names_section, /* clear */ true);
+      binary_->remove_section_at(shstr_idx, /*clear=*/true);
       Section sec_str_section(sec_name, Section::TYPE::STRTAB);
       sec_str_section.content(std::vector<uint8_t>(raw_shstrtab_.size()));
       Section* sec = binary_->add(sec_str_section, /*loaded=*/false,
@@ -1624,7 +1624,7 @@ class LIEF_LOCAL ExeLayout : public Layout {
         LIEF_DEBUG("Removing the old section: {} {:#x} (size: {:#x})",
                    strtab_section_->name(), strtab_section_->file_offset(),
                    strtab_section_->size());
-        binary_->remove(*strtab_section_, /* clear */ true);
+        binary_->remove_section_by_ptr(strtab_section_, /*clear=*/true);
       }
       Section strtab{".strtab", Section::TYPE::STRTAB};
       strtab.content(raw_strtab_);
@@ -1678,7 +1678,8 @@ class LIEF_LOCAL ExeLayout : public Layout {
         LIEF_DEBUG("Removing the old section: {} {:#x} (size: {:#x})",
                    it_sec_symtab->name(), it_sec_symtab->file_offset(),
                    it_sec_symtab->size());
-        binary_->remove(*it_sec_symtab, /* clear */ true);
+        Section* old_symtab = &*it_sec_symtab;
+        binary_->remove_section_by_ptr(old_symtab, /*clear=*/true);
         if (pos < strtab_idx) {
           --strtab_idx;
         }

--- a/src/ELF/ObjectFileLayout.hpp
+++ b/src/ELF/ObjectFileLayout.hpp
@@ -93,8 +93,13 @@ class LIEF_LOCAL ObjectFileLayout : public Layout {
 
       DataHandler::Node new_node{last_offset_sections, needed_size,
                                  DataHandler::Node::SECTION};
-      binary_->datahandler_->add(new_node);
       binary_->datahandler_->make_hole(last_offset_sections, needed_size);
+
+      sec.release_node();
+      sec.bind_node(
+        *binary_->datahandler_,
+        binary_->datahandler_->add(new_node)
+      );
 
       sec.offset(last_offset_sections);
       sec.size(needed_size);

--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -853,7 +853,14 @@ ok_error_t Parser::parse_sections() {
 
     if (section->size() == 0 && section->file_offset() > 0 && access_content) {
       // Even if the size is 0, it is worth creating the node
-      handler.create(section->file_offset(), 0, DataHandler::Node::SECTION);
+      section->bind_node(
+        handler,
+        handler.create(
+          section->file_offset(),
+          0,
+          DataHandler::Node::SECTION
+        )
+      );
     }
 
     // Only if it contains data (with bits)
@@ -872,14 +879,21 @@ ok_error_t Parser::parse_sections() {
         read_size = Section::MAX_SECTION_SIZE;
       }
 
-      handler.create(section->file_offset(), read_size,
-                     DataHandler::Node::SECTION);
+      section->bind_node(
+        handler,
+        handler.create(
+          section->file_offset(),
+          read_size,
+          DataHandler::Node::SECTION
+        )
+      );
 
       const Elf_Off offset_to_content = section->file_offset();
       auto alloc =
           binary_->datahandler_->reserve(section->file_offset(), read_size);
       if (!alloc) {
         LIEF_ERR("Can't allocate memory");
+        section->release_node();
         break;
       }
 
@@ -986,8 +1000,15 @@ ok_error_t Parser::parse_segments() {
         read_size = stream_->size();
       }
 
-      segment->datahandler_->create(segment->file_offset(), read_size,
-                                    DataHandler::Node::SEGMENT);
+      segment->bind_node(
+        *segment->datahandler_,
+        segment->datahandler_->create(
+          segment->file_offset(),
+          read_size,
+          DataHandler::Node::SEGMENT
+        )
+      );
+
       segment->handler_size_ = read_size;
 
       const bool corrupted_offset =
@@ -1000,6 +1021,7 @@ ok_error_t Parser::parse_segments() {
             binary_->datahandler_->reserve(segment->file_offset(), read_size);
         if (!alloc) {
           LIEF_ERR("Can't allocate memory");
+          segment->release_node();
           break;
         }
         /* The DataHandlerStream interface references ELF data that are
@@ -1029,9 +1051,15 @@ ok_error_t Parser::parse_segments() {
       }
     } else {
       segment->handler_size_ = segment->physical_size();
-      segment->datahandler_->create(segment->file_offset(),
-                                    segment->physical_size(),
-                                    DataHandler::Node::SEGMENT);
+
+      segment->bind_node(
+        *segment->datahandler_,
+        segment->datahandler_->create(
+          segment->file_offset(),
+          segment->physical_size(),
+          DataHandler::Node::SEGMENT
+        )
+      );
     }
 
     for (std::unique_ptr<Section>& section : binary_->sections_) {

--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -916,7 +916,9 @@ ok_error_t Parser::parse_sections() {
     }
     sections_idx_[i] = section.get();
     sections_names[section.get()] = shdr->sh_name;
+    Section* section_ptr = section.get();
     binary_->sections_.push_back(std::move(section));
+    binary_->publish_layout(*section_ptr);
   }
 
   LIEF_DEBUG("    Parse section names");
@@ -1068,7 +1070,9 @@ ok_error_t Parser::parse_segments() {
         segment->sections_.push_back(section.get());
       }
     }
+    Segment* segment_ptr = segment.get();
     binary_->segments_.push_back(std::move(segment));
+    binary_->publish_layout(*segment_ptr);
   }
   return ok();
 }

--- a/src/ELF/Parser.tcc
+++ b/src/ELF/Parser.tcc
@@ -943,6 +943,13 @@ ok_error_t Parser::parse_segments() {
   LIEF_DEBUG("Parsing segments");
   const Header& hdr = binary_->header();
   const Elf_Off segment_headers_offset = hdr.program_headers_offset();
+
+  static constexpr uint32_t PN_XNUM = 0xFFFF;
+  if (hdr.numberof_segments() == PN_XNUM) {
+    LIEF_WARN("Extended program-header numbering is not supported");
+    return make_error_code(lief_errors::not_supported);
+  }
+
   const auto nbof_segments =
       std::min<uint32_t>(hdr.numberof_segments(), Parser::NB_MAX_SEGMENTS);
 

--- a/src/ELF/Section.cpp
+++ b/src/ELF/Section.cpp
@@ -25,6 +25,7 @@
 
 #include "LIEF/ELF/Section.hpp"
 #include "LIEF/ELF/Segment.hpp"
+#include "LIEF/ELF/Binary.hpp"
 
 #include "LIEF/ELF/EnumToString.hpp"
 
@@ -146,6 +147,19 @@ Section::Section(const Section& other) :
   content_c_{other.content_c_} {}
 
 void Section::swap(Section& other) noexcept {
+  if (this == &other) {
+    return;
+  }
+
+  if (layout_observer_ != nullptr) {
+    layout_observer_->invalidate_append_file_end();
+  }
+
+  if (other.layout_observer_ != nullptr &&
+      other.layout_observer_ != layout_observer_) {
+    other.layout_observer_->invalidate_append_file_end();
+  }
+
   std::swap(name_, other.name_);
   std::swap(virtual_address_, other.virtual_address_);
   std::swap(offset_, other.offset_);
@@ -225,6 +239,29 @@ void Section::rebind_node_owner() noexcept {
   }
 }
 
+void Section::observe_layout(Binary& binary) noexcept {
+  assert(layout_observer_ == nullptr);
+
+  layout_observer_ = &binary;
+}
+
+void Section::stop_observing_layout() noexcept {
+  assert(layout_observer_ != nullptr);
+  layout_observer_ = nullptr;
+}
+
+void Section::notify_layout_change(
+    bool old_contributes, uint64_t old_offset, uint64_t old_size,
+    bool new_contributes, uint64_t new_offset, uint64_t new_size) noexcept {
+  if (layout_observer_ == nullptr) {
+    return;
+  }
+  layout_observer_->update_layout_extent(
+    old_contributes, old_offset, old_size,
+    new_contributes, new_offset, new_size
+  );
+}
+
 bool Section::has(const Segment& segment) const {
   auto it_segment = std::find_if(segments_.begin(), segments_.end(),
                                  [&segment](Segment* s) { return *s == segment; });
@@ -233,6 +270,10 @@ bool Section::has(const Segment& segment) const {
 
 
 void Section::size(uint64_t size) {
+  const uint64_t old_size = size_;
+  const bool layout_changed = old_size != size;
+  const bool contributes = type() != TYPE::NOBITS && !is_frame();
+
   if (datahandler_ != nullptr && !is_frame()) {
     if (node_ != nullptr) {
       node_->size(size);
@@ -244,10 +285,21 @@ void Section::size(uint64_t size) {
     }
   }
   size_ = size;
+
+  if (layout_changed) {
+    notify_layout_change(
+      contributes, offset_, old_size,
+      contributes, offset_, size
+    );
+  }
 }
 
 
 void Section::offset(uint64_t offset) {
+  const uint64_t old_offset = offset_;
+  const bool layout_changed = old_offset != offset;
+  const bool contributes = type() != TYPE::NOBITS && !is_frame();
+
   if (datahandler_ != nullptr && !is_frame()) {
     if (node_ != nullptr) {
       node_->offset(offset);
@@ -258,6 +310,13 @@ void Section::offset(uint64_t offset) {
     }
   }
   offset_ = offset;
+
+  if (layout_changed) {
+    notify_layout_change(
+      contributes, old_offset, size_,
+      contributes, offset, size_
+    );
+  }
 }
 
 span<const uint8_t> Section::content() const {
@@ -441,6 +500,24 @@ void Section::remove(Section::FLAGS flag) {
   flags(flags() & (~raw_flag));
 }
 
+void Section::type(TYPE type) {
+  if (type_ == type) {
+    return;
+  }
+
+  const bool contributed_before = type_ != TYPE::NOBITS && !is_frame();
+  const bool contributes_after = type != TYPE::NOBITS && !is_frame();
+
+  type_ = type;
+
+  if (contributed_before != contributes_after) {
+    notify_layout_change(
+      contributed_before, offset_, size_,
+      contributes_after, offset_, size_
+    );
+  }
+}
+
 Section& Section::clear(uint8_t value) {
   if (is_frame()) {
     return *this;
@@ -458,6 +535,22 @@ Section& Section::clear(uint8_t value) {
   DataHandler::Node& node = *node_;
 
   std::fill_n(binary_content.begin() + node.offset(), size(), value);
+  return *this;
+}
+
+Section& Section::as_frame() {
+  if (is_frame_) {
+    return *this;
+  }
+
+  const bool contributed_before = type() != TYPE::NOBITS;
+
+  is_frame_ = true;
+
+  if (contributed_before) {
+    notify_layout_change(true, offset_, size_, false, offset_, size_);
+  }
+
   return *this;
 }
 

--- a/src/ELF/Section.cpp
+++ b/src/ELF/Section.cpp
@@ -128,6 +128,10 @@ Section::Section(const T& header, ARCH arch) :
 template Section::Section(const details::Elf32_Shdr& header, ARCH);
 template Section::Section(const details::Elf64_Shdr& header, ARCH);
 
+Section::~Section() {
+  release_node();
+}
+
 Section::Section(const Section& other) :
   LIEF::Section{other},
   arch_{other.arch_},
@@ -158,7 +162,67 @@ void Section::swap(Section& other) noexcept {
   std::swap(segments_, other.segments_);
   std::swap(is_frame_, other.is_frame_);
   std::swap(datahandler_, other.datahandler_);
+  std::swap(node_, other.node_);
   std::swap(content_c_, other.content_c_);
+
+  rebind_node_owner();
+  other.rebind_node_owner();
+}
+
+void Section::invalidate_node_owner(void* owner,
+                                    DataHandler::Node& node) noexcept {
+  assert(owner != nullptr);
+
+  Section& section = *static_cast<Section*>(owner);
+
+  assert(section.node_ == &node);
+  (void)node;
+
+  section.node_ = nullptr;
+  section.datahandler_ = nullptr;
+}
+
+void Section::bind_node(DataHandler::Handler& handler,
+                        DataHandler::Node& node) {
+  assert(node.type() == DataHandler::Node::SECTION);
+  assert(node_ == nullptr);
+  assert(datahandler_ == nullptr || datahandler_ == &handler);
+  assert(!node.has_owner());
+
+  datahandler_ = &handler;
+  node_ = &node;
+
+  node.bind_owner(this, &Section::invalidate_node_owner);
+
+  assert(handler.owns(node));
+}
+
+void Section::release_node() noexcept {
+  if (node_ == nullptr) {
+    return;
+  }
+
+  assert(datahandler_ != nullptr);
+
+  DataHandler::Handler* handler = datahandler_;
+  DataHandler::Node* node = node_;
+
+  assert(handler->owns(*node));
+
+  const bool removed = handler->remove(*node);
+  assert(removed);
+  if (!removed) {
+    std::abort();
+  }
+
+  assert(node_ == nullptr);
+  assert(datahandler_ == nullptr);
+}
+
+void Section::rebind_node_owner() noexcept {
+  if (node_ != nullptr) {
+    node_->rebind_owner(this);
+  }
 }
 
 bool Section::has(const Segment& segment) const {
@@ -170,10 +234,8 @@ bool Section::has(const Segment& segment) const {
 
 void Section::size(uint64_t size) {
   if (datahandler_ != nullptr && !is_frame()) {
-    if (auto node = datahandler_->get(file_offset(), this->size(),
-                                      DataHandler::Node::SECTION))
-    {
-      node->get().size(size);
+    if (node_ != nullptr) {
+      node_->size(size);
     } else {
       if (type() != TYPE::NOBITS) {
         LIEF_ERR("Node not found, cannot resize section '{}'", name());
@@ -187,10 +249,8 @@ void Section::size(uint64_t size) {
 
 void Section::offset(uint64_t offset) {
   if (datahandler_ != nullptr && !is_frame()) {
-    if (auto node =
-            datahandler_->get(file_offset(), size(), DataHandler::Node::SECTION))
-    {
-      node->get().offset(offset);
+    if (node_ != nullptr) {
+      node_->offset(offset);
     } else {
       if (type() != TYPE::NOBITS) {
         LIEF_WARN("Node not found, cannot change offset of section '{}'", name());
@@ -213,15 +273,15 @@ span<const uint8_t> Section::content() const {
     return {};
   }
 
-  auto res = datahandler_->get(offset(), size(), DataHandler::Node::SECTION);
-  if (!res) {
+  if (node_ == nullptr) {
     if (type() != TYPE::NOBITS) {
       LIEF_WARN("Section '{}' has no content", name());
     }
     return {};
   }
   const std::vector<uint8_t>& binary_content = datahandler_->content();
-  DataHandler::Node& node = res.value();
+
+  const DataHandler::Node& node = *node_;
   auto end_offset = (int64_t)node.offset() + (int64_t)node.size();
   if (end_offset <= 0 || end_offset > (int64_t)binary_content.size()) {
     return {};
@@ -260,13 +320,12 @@ void Section::content(const std::vector<uint8_t>& data) {
              data.size(), file_offset(), name());
 
 
-  auto res = datahandler_->get(file_offset(), size(), DataHandler::Node::SECTION);
-  if (!res) {
+  if (node_ == nullptr) {
     LIEF_ERR("Node not found, section content cannot be updated");
     return;
   }
 
-  DataHandler::Node& node = res.value();
+  DataHandler::Node& node = *node_;
 
   std::vector<uint8_t>& binary_content = datahandler_->content();
   datahandler_->reserve(node.offset(), data.size());
@@ -308,12 +367,11 @@ void Section::content(std::vector<uint8_t>&& data) {
   LIEF_DEBUG("Setting {:#x} bytes in data handler@{:#x} of section '{}'",
              data.size(), file_offset(), name());
 
-  auto res = datahandler_->get(file_offset(), size(), DataHandler::Node::SECTION);
-  if (!res) {
+  if (node_ == nullptr) {
     LIEF_ERR("Node not found, section content cannot be updated");
     return;
   }
-  DataHandler::Node& node = res.value();
+  DataHandler::Node& node = *node_;
 
   std::vector<uint8_t>& binary_content = datahandler_->content();
   datahandler_->reserve(node.offset(), data.size());
@@ -393,12 +451,11 @@ Section& Section::clear(uint8_t value) {
   }
 
   std::vector<uint8_t>& binary_content = datahandler_->content();
-  auto res = datahandler_->get(file_offset(), size(), DataHandler::Node::SECTION);
-  if (!res) {
+  if (node_ == nullptr) {
     LIEF_ERR("Node not found, section content cannot be cleared");
     return *this;
   }
-  DataHandler::Node& node = res.value();
+  DataHandler::Node& node = *node_;
 
   std::fill_n(binary_content.begin() + node.offset(), size(), value);
   return *this;

--- a/src/ELF/Segment.cpp
+++ b/src/ELF/Segment.cpp
@@ -104,7 +104,15 @@ Segment::Segment(const T& header, ARCH arch, Header::OS_ABI os) :
 template Segment::Segment(const details::Elf32_Phdr& header, ARCH, Header::OS_ABI);
 template Segment::Segment(const details::Elf64_Phdr& header, ARCH, Header::OS_ABI);
 
-void Segment::swap(Segment& other) {
+Segment::~Segment() {
+  release_node();
+}
+
+Segment::Segment(Segment&& other) noexcept {
+  swap(other);
+}
+
+void Segment::swap(Segment& other) noexcept {
   std::swap(type_, other.type_);
   std::swap(arch_, other.arch_);
   std::swap(flags_, other.flags_);
@@ -117,7 +125,67 @@ void Segment::swap(Segment& other) {
   std::swap(handler_size_, other.handler_size_);
   std::swap(sections_, other.sections_);
   std::swap(datahandler_, other.datahandler_);
+  std::swap(node_, other.node_);
   std::swap(content_c_, other.content_c_);
+
+  rebind_node_owner();
+  other.rebind_node_owner();
+}
+
+void Segment::invalidate_node_owner(void* owner,
+                                    DataHandler::Node& node) noexcept {
+  assert(owner != nullptr);
+
+  Segment& segment = *static_cast<Segment*>(owner);
+
+  assert(segment.node_ == &node);
+  (void)node;
+
+  segment.node_ = nullptr;
+  segment.datahandler_ = nullptr;
+}
+
+void Segment::bind_node(DataHandler::Handler& handler,
+                        DataHandler::Node& node) {
+  assert(node.type() == DataHandler::Node::SEGMENT);
+  assert(node_ == nullptr);
+  assert(datahandler_ == nullptr || datahandler_ == &handler);
+  assert(!node.has_owner());
+
+  datahandler_ = &handler;
+  node_ = &node;
+
+  node.bind_owner(this, &Segment::invalidate_node_owner);
+
+  assert(handler.owns(node));
+}
+
+void Segment::release_node() noexcept {
+  if (node_ == nullptr) {
+    return;
+  }
+
+  assert(datahandler_ != nullptr);
+
+  DataHandler::Handler* handler = datahandler_;
+  DataHandler::Node* node = node_;
+
+  assert(handler->owns(*node));
+
+  const bool removed = handler->remove(*node);
+  assert(removed);
+  if (!removed) {
+    std::abort();
+  }
+
+  assert(node_ == nullptr);
+  assert(datahandler_ == nullptr);
+}
+
+void Segment::rebind_node_owner() noexcept {
+  if (node_ != nullptr) {
+    node_->rebind_owner(this);
+  }
 }
 
 Segment& Segment::operator=(Segment other) {
@@ -150,13 +218,11 @@ span<const uint8_t> Segment::content() const {
     return content_c_;
   }
 
-  auto res =
-      datahandler_->get(file_offset(), handler_size(), DataHandler::Node::SEGMENT);
-  if (!res) {
+  if (node_ == nullptr) {
     LIEF_ERR("Node not found, segment content inaccessible");
     return {};
   }
-  DataHandler::Node& node = res.value();
+  const DataHandler::Node& node = *node_;
 
   // Create a span based on our values
   const std::vector<uint8_t>& binary_content = datahandler_->content();
@@ -178,6 +244,7 @@ span<const uint8_t> Segment::content() const {
     if ((node.offset() + handler_size()) <= size) {
       return {ptr, static_cast<size_t>(handler_size())};
     }
+
     LIEF_ERR("Failed to access segment content {}:{:#x}", to_string(type()),
              virtual_address());
     return {};
@@ -190,14 +257,11 @@ size_t Segment::get_content_size() const {
   if (datahandler_ == nullptr) {
     return content_c_.size();
   }
-  auto res =
-      datahandler_->get(file_offset(), handler_size(), DataHandler::Node::SEGMENT);
-  if (!res) {
+  if (node_ == nullptr) {
     LIEF_ERR("Node not found");
     return 0;
   }
-  DataHandler::Node& node = res.value();
-  return node.size();
+  return node_->size();
 }
 
 template<typename T>
@@ -208,15 +272,13 @@ T Segment::get_content_value(size_t offset) const {
                virtual_address());
     memcpy(&ret, content_c_.data() + offset, sizeof(T));
   } else {
-    auto res = datahandler_->get(file_offset(), handler_size(),
-                                 DataHandler::Node::SEGMENT);
-    if (!res) {
+    if (node_ == nullptr) {
       LIEF_ERR("Node not found for this segment");
       memset(&ret, 0, sizeof(T));
       return ret;
     }
     const std::vector<uint8_t>& binary_content = datahandler_->content();
-    DataHandler::Node& node = res.value();
+    const DataHandler::Node& node = *node_;
     memcpy(&ret, binary_content.data() + node.offset() + offset, sizeof(T));
   }
   return ret;
@@ -242,13 +304,11 @@ void Segment::set_content_value(size_t offset, T value) {
     }
     memcpy(content_c_.data() + offset, &value, sizeof(T));
   } else {
-    auto res = datahandler_->get(file_offset(), handler_size(),
-                                 DataHandler::Node::SEGMENT);
-    if (!res) {
+    if (node_ == nullptr) {
       LIEF_ERR("Node not found for this segment, content cannot be updated");
       return;
     }
-    DataHandler::Node& node = res.value();
+    DataHandler::Node& node = *node_;
     std::vector<uint8_t>& binary_content = datahandler_->content();
 
     if (offset + sizeof(T) > binary_content.size()) {
@@ -292,24 +352,19 @@ void Segment::remove(Segment::FLAGS flag) {
 
 void Segment::file_offset(uint64_t file_offset) {
   if (datahandler_ != nullptr) {
-    auto res = datahandler_->get(this->file_offset(), handler_size(),
-                                 DataHandler::Node::SEGMENT);
-    if (res) {
-      res->get().offset(file_offset);
-    } else {
+    if (node_ == nullptr) {
       LIEF_ERR("Node not found, file offset cannot be updated");
       return;
     }
+    node_->offset(file_offset);
   }
   file_offset_ = file_offset;
 }
 
 void Segment::physical_size(uint64_t physical_size) {
   if (datahandler_ != nullptr) {
-    auto node = datahandler_->get(file_offset(), handler_size(),
-                                  DataHandler::Node::SEGMENT);
-    if (node) {
-      node->get().size(physical_size);
+    if (node_ != nullptr) {
+      node_->size(physical_size);
       handler_size_ = physical_size;
     } else {
       LIEF_ERR("Node not found, physical size cannot be updated");
@@ -332,13 +387,11 @@ void Segment::content(std::vector<uint8_t> content) {
       to_string(type()), virtual_address(), file_offset(), content.size()
   );
 
-  auto res =
-      datahandler_->get(file_offset(), handler_size(), DataHandler::Node::SEGMENT);
-  if (!res) {
+  if (node_ == nullptr) {
     LIEF_ERR("Node not found for content update");
     return;
   }
-  DataHandler::Node& node = res.value();
+  DataHandler::Node& node = *node_;
 
   std::vector<uint8_t>& binary_content = datahandler_->content();
   datahandler_->reserve(node.offset(), content.size());

--- a/src/ELF/Segment.cpp
+++ b/src/ELF/Segment.cpp
@@ -25,6 +25,7 @@
 #include "LIEF/ELF/Segment.hpp"
 #include "LIEF/ELF/EnumToString.hpp"
 #include "LIEF/ELF/Section.hpp"
+#include "LIEF/ELF/Binary.hpp"
 
 #include "ELF/DataHandler/Handler.hpp"
 #include "ELF/Structures.hpp"
@@ -113,6 +114,19 @@ Segment::Segment(Segment&& other) noexcept {
 }
 
 void Segment::swap(Segment& other) noexcept {
+  if (this == &other) {
+    return;
+  }
+
+  if (layout_observer_ != nullptr) {
+    layout_observer_->invalidate_append_file_end();
+  }
+
+  if (other.layout_observer_ != nullptr &&
+      other.layout_observer_ != layout_observer_) {
+    other.layout_observer_->invalidate_append_file_end();
+  }
+
   std::swap(type_, other.type_);
   std::swap(arch_, other.arch_);
   std::swap(flags_, other.flags_);
@@ -186,6 +200,29 @@ void Segment::rebind_node_owner() noexcept {
   if (node_ != nullptr) {
     node_->rebind_owner(this);
   }
+}
+
+void Segment::observe_layout(Binary& binary) noexcept {
+  assert(layout_observer_ == nullptr);
+
+  layout_observer_ = &binary;
+}
+
+void Segment::stop_observing_layout() noexcept {
+  assert(layout_observer_ != nullptr);
+  layout_observer_ = nullptr;
+}
+
+void Segment::notify_layout_change(
+    bool old_contributes, uint64_t old_offset, uint64_t old_size,
+    bool new_contributes, uint64_t new_offset, uint64_t new_size) noexcept {
+  if (layout_observer_ == nullptr) {
+    return;
+  }
+  layout_observer_->update_layout_extent(
+    old_contributes, old_offset, old_size,
+    new_contributes, new_offset, new_size
+  );
 }
 
 Segment& Segment::operator=(Segment other) {
@@ -351,6 +388,9 @@ void Segment::remove(Segment::FLAGS flag) {
 }
 
 void Segment::file_offset(uint64_t file_offset) {
+  const uint64_t old_offset = file_offset_;
+  const bool layout_changed = old_offset != file_offset;
+
   if (datahandler_ != nullptr) {
     if (node_ == nullptr) {
       LIEF_ERR("Node not found, file offset cannot be updated");
@@ -359,9 +399,16 @@ void Segment::file_offset(uint64_t file_offset) {
     node_->offset(file_offset);
   }
   file_offset_ = file_offset;
+
+  if (layout_changed) {
+    notify_layout_change(true, old_offset, size_, true, file_offset, size_);
+  }
 }
 
 void Segment::physical_size(uint64_t physical_size) {
+  const uint64_t old_size = size_;
+  const bool layout_changed = old_size != physical_size;
+
   if (datahandler_ != nullptr) {
     if (node_ != nullptr) {
       node_->size(physical_size);
@@ -371,6 +418,13 @@ void Segment::physical_size(uint64_t physical_size) {
     }
   }
   size_ = physical_size;
+
+  if (layout_changed) {
+    notify_layout_change(
+      true, file_offset_, old_size,
+      true, file_offset_, physical_size
+    );
+  }
 }
 
 void Segment::content(std::vector<uint8_t> content) {

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(unittests
   test_iostream.cpp
   test_pe.cpp
   test_elf.cpp
+  test_elf_append_extent.cpp
   test_oat.cpp
   test_linux_header.cpp
 )

--- a/tests/unittests/test_elf_append_extent.cpp
+++ b/tests/unittests/test_elf_append_extent.cpp
@@ -1,0 +1,645 @@
+/* Copyright 2017 - 2026 R. Thomas
+ * Copyright 2017 - 2026 Quarkslab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "LIEF/ELF/Binary.hpp"
+#include "LIEF/ELF/Header.hpp"
+#include "LIEF/ELF/Parser.hpp"
+#include "LIEF/ELF/Section.hpp"
+#include "LIEF/ELF/Segment.hpp"
+
+#include "utils.hpp"
+
+using namespace LIEF;
+
+namespace {
+
+uint64_t recompute_extent(const ELF::Binary& binary) {
+  uint64_t maximum = 0;
+
+  for (const ELF::Section& section : binary.sections()) {
+    if (section.is_frame() || section.type() == ELF::Section::TYPE::NOBITS) {
+      continue;
+    }
+
+    maximum = std::max(maximum, section.file_offset() + section.size());
+  }
+
+  for (const ELF::Segment& segment : binary.segments()) {
+    maximum = std::max(maximum,
+                       segment.file_offset() + segment.physical_size());
+  }
+
+  return maximum;
+}
+
+uint64_t align_up(uint64_t value, uint64_t align) {
+  if (align == 0) {
+    return value;
+  }
+
+  const uint64_t remainder = value % align;
+  if (remainder == 0) {
+    return value;
+  }
+
+  return value + align - remainder;
+}
+
+ELF::Segment make_probe_segment(const ELF::Binary& binary) {
+  ELF::Segment probe;
+  probe.type(ELF::Segment::TYPE::LOAD);
+  probe.alignment(binary.page_size());
+  probe.content(std::vector<uint8_t>{0xCC});
+  return probe;
+}
+
+ELF::Segment* append_and_check(ELF::Binary& binary) {
+  REQUIRE((binary.header().file_type() == ELF::Header::FILE_TYPE::EXEC));
+
+  const uint64_t expected_offset = align_up(
+    recompute_extent(binary),
+    binary.page_size()
+  );
+
+  ELF::Segment probe = make_probe_segment(binary);
+  ELF::Segment* added = binary.add(probe);
+
+  REQUIRE(added != nullptr);
+  CHECK(added->file_offset() == expected_offset);
+  return added;
+}
+
+std::unique_ptr<ELF::Binary> parse_exec() {
+  const std::string path = test::get_elf_sample(
+    "ELF64_x86-64_binary_static-binary.bin"
+  );
+
+  std::unique_ptr<ELF::Binary> binary = ELF::Parser::parse(path);
+  REQUIRE(binary != nullptr);
+  REQUIRE((binary->header().file_type() == ELF::Header::FILE_TYPE::EXEC));
+  return binary;
+}
+
+std::unique_ptr<ELF::Binary> make_segment_gap_exec() {
+  std::unique_ptr<ELF::Binary> binary = parse_exec();
+
+  const uint64_t phdr_size = binary->header().program_header_size();
+  REQUIRE(phdr_size != 0);
+
+  const auto current_phdrs =
+    static_cast<uint64_t>(binary->header().numberof_segments());
+
+  // relocate_phdr_table_v1() subtracts the current PHDR count from the
+  // number of entries that fit in the gap, then requires the remainder to
+  // be at least the current PHDR count. Add one entry as margin.
+  const uint64_t required_entries = 2 * current_phdrs + 1;
+  const uint64_t required_gap = required_entries * phdr_size;
+
+  std::vector<ELF::Segment*> loads;
+  for (ELF::Segment& segment : binary->segments()) {
+    if (segment.is_load()) {
+      loads.push_back(&segment);
+    }
+  }
+
+  REQUIRE(loads.size() >= 2);
+
+  ELF::Segment* current = nullptr;
+  ELF::Segment* adjacent = nullptr;
+
+  for (size_t i = 0; i + 1 < loads.size(); ++i) {
+    ELF::Segment* candidate = loads[i];
+    ELF::Segment* next = loads[i + 1];
+
+    if (candidate->virtual_size() != candidate->physical_size()) {
+      continue;
+    }
+
+    // Create the gap
+    if (next->file_offset() <= candidate->file_offset() + required_gap) {
+      continue;
+    }
+
+    current = candidate;
+    adjacent = next;
+    break;
+  }
+
+  REQUIRE(current != nullptr);
+  REQUIRE(adjacent != nullptr);
+
+  const uint64_t new_size = adjacent->file_offset() -
+                            current->file_offset() -
+                            required_gap;
+
+  REQUIRE(new_size > 0);
+
+  current->physical_size(new_size);
+  current->virtual_size(new_size);
+
+  const uint64_t actual_gap =
+    adjacent->file_offset() -
+    (current->file_offset() + current->physical_size());
+
+  const uint64_t available_entries = actual_gap / phdr_size;
+
+  REQUIRE(available_entries >= required_entries);
+  REQUIRE(available_entries - current_phdrs >= current_phdrs);
+
+  return binary;
+}
+
+std::unique_ptr<ELF::Binary> make_relocated_exec() {
+  std::unique_ptr<ELF::Binary> binary = parse_exec();
+
+  REQUIRE(binary->reserve_segments(256));
+  REQUIRE(binary->relocate_phdr_table(
+            ELF::Binary::PHDR_RELOC::BINARY_END) != 0);
+
+  // Establish a valid cache and a known final maximum contributor
+  append_and_check(*binary);
+  return binary;
+}
+
+bool is_mutable_file_backed_section(const ELF::Section& section) {
+  return !section.is_frame() &&
+         section.type() != ELF::Section::TYPE::SHT_NULL_ &&
+         section.type() != ELF::Section::TYPE::NOBITS &&
+         section.size() != 0;
+}
+
+ELF::Section* first_file_backed_section(ELF::Binary& binary) {
+  for (ELF::Section& section : binary.sections()) {
+    if (is_mutable_file_backed_section(section)) {
+      return &section;
+    }
+  }
+  return nullptr;
+}
+
+ELF::Section* second_file_backed_section(ELF::Binary& binary) {
+  bool found_first = false;
+
+  for (ELF::Section& section : binary.sections()) {
+    if (!is_mutable_file_backed_section(section)) {
+      continue;
+    }
+
+    if (!found_first) {
+      found_first = true;
+      continue;
+    }
+
+    return &section;
+  }
+  return nullptr;
+}
+
+ELF::Segment* first_segment(ELF::Binary& binary) {
+  for (ELF::Segment& segment : binary.segments()) {
+    return &segment;
+  }
+  return nullptr;
+}
+
+ELF::Segment* last_segment(ELF::Binary& binary) {
+  ELF::Segment* result = nullptr;
+
+  for (ELF::Segment& segment : binary.segments()) {
+    result = &segment;
+  }
+  return result;
+}
+
+void relocate_and_check(ELF::Binary& binary, ELF::Binary::PHDR_RELOC strategy) {
+  const uint64_t result = binary.relocate_phdr_table(strategy);
+  REQUIRE(result != 0);
+
+  if (binary.header().file_type() != ELF::Header::FILE_TYPE::EXEC) {
+    // add_segment<EXEC> is the cache consumer
+    binary.header().file_type(ELF::Header::FILE_TYPE::EXEC);
+  }
+
+  append_and_check(binary);
+}
+
+} // namespace
+
+TEST_CASE("ELF append extent: parse and repeated additions",
+          "[lief][elf][append-extent]") {
+  SECTION("first addition after parser publication") {
+    std::unique_ptr<ELF::Binary> binary = parse_exec();
+
+    REQUIRE(binary->reserve_segments(256));
+    REQUIRE(binary->relocate_phdr_table(
+              ELF::Binary::PHDR_RELOC::BINARY_END) != 0);
+
+    append_and_check(*binary);
+  }
+
+  SECTION("repeated ET_EXEC additions") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+
+    for (size_t i = 0; i < 128; ++i) {
+      append_and_check(*binary);
+    }
+  }
+}
+
+TEST_CASE("ELF append extent: maximum contributors",
+          "[lief][elf][append-extent]") {
+  SECTION("section-only maximum") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* section = first_file_backed_section(*binary);
+    REQUIRE(section != nullptr);
+
+    const uint64_t previous_end = recompute_extent(*binary);
+    const uint64_t page = binary->page_size();
+
+    section->size(0);
+    section->offset(previous_end + page);
+    section->size(page);
+
+    append_and_check(*binary);
+  }
+
+  SECTION("segment-only maximum") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+
+    // The probe inserted by make_relocated_exec() is the unique final segment
+    append_and_check(*binary);
+  }
+
+  SECTION("equal section and segment maxima") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* section = first_file_backed_section(*binary);
+    ELF::Segment* segment = last_segment(*binary);
+
+    REQUIRE(section != nullptr);
+    REQUIRE(segment != nullptr);
+
+    const uint64_t maximum = segment->file_offset() + segment->physical_size();
+
+    section->size(0);
+    section->offset(maximum);
+    section->size(0);
+
+    append_and_check(*binary);
+  }
+}
+
+TEST_CASE("ELF append extent: incremental size and offset changes",
+          "[lief][elf][append-extent]") {
+  SECTION("grow a nonmaximum section") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* section = first_file_backed_section(*binary);
+    REQUIRE(section != nullptr);
+
+    const uint64_t maximum = recompute_extent(*binary);
+
+    section->offset(0);
+    section->size(std::min<uint64_t>(maximum / 2, 0x2000));
+    section->size(section->size() + 1);
+
+    REQUIRE(section->file_offset() + section->size() < maximum);
+    append_and_check(*binary);
+  }
+
+  SECTION("shrink a nonmaximum section") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* section = first_file_backed_section(*binary);
+    REQUIRE(section != nullptr);
+
+    const uint64_t maximum = recompute_extent(*binary);
+
+    section->offset(0);
+    section->size(std::min<uint64_t>(maximum / 2, 0x2000));
+    REQUIRE(section->size() > 0);
+    section->size(section->size() - 1);
+
+    REQUIRE(section->file_offset() + section->size() < maximum);
+    append_and_check(*binary);
+  }
+
+  SECTION("grow the maximum") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Segment* maximum = last_segment(*binary);
+    REQUIRE(maximum != nullptr);
+
+    maximum->physical_size(maximum->physical_size() + binary->page_size());
+
+    append_and_check(*binary);
+  }
+
+  SECTION("shrink one of multiple maximum contributors") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* section = first_file_backed_section(*binary);
+    ELF::Segment* segment = last_segment(*binary);
+
+    REQUIRE(section != nullptr);
+    REQUIRE(segment != nullptr);
+
+    const uint64_t maximum = segment->file_offset() + segment->physical_size();
+
+    section->size(0);
+    section->offset(maximum);
+    section->size(0);
+
+    section->offset(0);
+
+    // ...the segment remains at maximum...
+
+    append_and_check(*binary);
+  }
+
+  SECTION("shrink the last maximum contributor") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Segment* maximum = last_segment(*binary);
+    REQUIRE(maximum != nullptr);
+
+    maximum->physical_size(0);
+    maximum->file_offset(0);
+
+    append_and_check(*binary);
+  }
+}
+
+TEST_CASE("ELF append extent: section contribution transitions",
+          "[lief][elf][append-extent]") {
+  SECTION("PROGBITS to NOBITS") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* section = first_file_backed_section(*binary);
+    REQUIRE(section != nullptr);
+
+    const uint64_t previous_end = recompute_extent(*binary);
+    const uint64_t page = binary->page_size();
+
+    section->size(0);
+    section->offset(previous_end + page);
+    section->size(page);
+
+    REQUIRE(recompute_extent(*binary) == previous_end + 2 * page);
+
+    section->type(ELF::Section::TYPE::NOBITS);
+    append_and_check(*binary);
+  }
+
+  SECTION("NOBITS to PROGBITS") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* section = first_file_backed_section(*binary);
+    REQUIRE(section != nullptr);
+
+    const uint64_t previous_end = recompute_extent(*binary);
+    const uint64_t page = binary->page_size();
+
+    section->type(ELF::Section::TYPE::NOBITS);
+    section->size(page);
+    section->offset(previous_end + page);
+    section->type(ELF::Section::TYPE::PROGBITS);
+
+    append_and_check(*binary);
+  }
+
+  SECTION("convert maximum section to frame") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* section = first_file_backed_section(*binary);
+    REQUIRE(section != nullptr);
+
+    const uint64_t previous_end = recompute_extent(*binary);
+    const uint64_t page = binary->page_size();
+
+    section->size(0);
+    section->offset(previous_end + page);
+    section->size(page);
+    section->as_frame();
+
+    append_and_check(*binary);
+  }
+
+  SECTION("publish an already-framed section") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+
+    ELF::Section frame{".append_extent_frame", ELF::Section::TYPE::PROGBITS};
+    frame.offset(std::numeric_limits<uint64_t>::max() - 0x2000);
+    frame.size(0x1000);
+    frame.as_frame();
+
+    ELF::Section* added = binary->add(frame, false);
+    REQUIRE(added != nullptr);
+    REQUIRE(added->is_frame());
+
+    append_and_check(*binary);
+  }
+}
+
+TEST_CASE("ELF append extent: removal and replacement",
+          "[lief][elf][append-extent]") {
+  SECTION("remove section") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* section = first_file_backed_section(*binary);
+    REQUIRE(section != nullptr);
+
+    binary->remove(*section, false);
+    append_and_check(*binary);
+  }
+
+  SECTION("remove maximum segment") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Segment* segment = last_segment(*binary);
+    REQUIRE(segment != nullptr);
+
+    binary->remove(*segment, false);
+    append_and_check(*binary);
+  }
+
+  SECTION("replace segment") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Segment* original = last_segment(*binary);
+    REQUIRE(original != nullptr);
+
+    ELF::Segment replacement{*original};
+    replacement.file_offset(recompute_extent(*binary) + binary->page_size());
+    replacement.content(std::vector<uint8_t>(0x80, 0x5a));
+    replacement.physical_size(0x80);
+    replacement.virtual_size(0x80);
+
+    ELF::Segment* inserted = binary->replace(replacement, *original);
+    REQUIRE(inserted != nullptr);
+
+    append_and_check(*binary);
+  }
+}
+
+TEST_CASE("ELF append extent: attached-object assignment",
+          "[lief][elf][append-extent]") {
+  SECTION("section assignment") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* attached = first_file_backed_section(*binary);
+    REQUIRE(attached != nullptr);
+
+    ELF::Section replacement{".replacement", ELF::Section::TYPE::PROGBITS};
+    replacement.offset(recompute_extent(*binary) + binary->page_size());
+    replacement.size(binary->page_size());
+
+    *attached = replacement;
+    append_and_check(*binary);
+  }
+
+  SECTION("segment assignment") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Segment* attached = first_segment(*binary);
+    REQUIRE(attached != nullptr);
+
+    ELF::Segment replacement;
+    replacement.type(ELF::Segment::TYPE::LOAD);
+    replacement.file_offset(recompute_extent(*binary) + binary->page_size());
+    replacement.physical_size(binary->page_size());
+    replacement.virtual_size(binary->page_size());
+
+    *attached = replacement;
+    append_and_check(*binary);
+  }
+}
+
+TEST_CASE("ELF append extent: attached and detached swaps",
+          "[lief][elf][append-extent]") {
+  SECTION("section swap") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Section* attached = first_file_backed_section(*binary);
+    REQUIRE(attached != nullptr);
+
+    ELF::Section detached{".detached", ELF::Section::TYPE::PROGBITS};
+    detached.offset(recompute_extent(*binary) + binary->page_size());
+    detached.size(binary->page_size());
+
+    attached->swap(detached);
+    append_and_check(*binary);
+  }
+
+  SECTION("segment swap") {
+    std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+    ELF::Segment* attached = first_segment(*binary);
+    REQUIRE(attached != nullptr);
+
+    ELF::Segment detached;
+    detached.type(ELF::Segment::TYPE::LOAD);
+    detached.file_offset(recompute_extent(*binary) + binary->page_size());
+    detached.physical_size(binary->page_size());
+    detached.virtual_size(binary->page_size());
+
+    attached->swap(detached);
+    append_and_check(*binary);
+  }
+}
+
+TEST_CASE("ELF append extent: cross-binary swaps",
+          "[lief][elf][append-extent]") {
+  SECTION("section swap across binaries") {
+    std::unique_ptr<ELF::Binary> lhs = make_relocated_exec();
+    std::unique_ptr<ELF::Binary> rhs = make_relocated_exec();
+
+    ELF::Section* lhs_section = first_file_backed_section(*lhs);
+    ELF::Section* rhs_section = second_file_backed_section(*rhs);
+
+    REQUIRE(lhs_section != nullptr);
+    REQUIRE(rhs_section != nullptr);
+
+    lhs_section->swap(*rhs_section);
+
+    append_and_check(*lhs);
+    append_and_check(*rhs);
+  }
+
+  SECTION("segment swap across binaries") {
+    std::unique_ptr<ELF::Binary> lhs = make_relocated_exec();
+    std::unique_ptr<ELF::Binary> rhs = make_relocated_exec();
+
+    ELF::Segment* lhs_segment = first_segment(*lhs);
+    ELF::Segment* rhs_segment = last_segment(*rhs);
+
+    REQUIRE(lhs_segment != nullptr);
+    REQUIRE(rhs_segment != nullptr);
+
+    lhs_segment->swap(*rhs_segment);
+
+    append_and_check(*lhs);
+    append_and_check(*rhs);
+  }
+}
+
+TEST_CASE("ELF append extent: section and segment shifts",
+          "[lief][elf][append-extent]") {
+  std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+  ELF::Segment* segment = first_segment(*binary);
+  REQUIRE(segment != nullptr);
+
+  REQUIRE(binary->extend(*segment, binary->page_size()));
+  append_and_check(*binary);
+}
+
+TEST_CASE("ELF append extent: empty layout",
+          "[lief][elf][append-extent]") {
+  std::unique_ptr<ELF::Binary> binary = make_relocated_exec();
+
+  std::vector<ELF::Section*> sections;
+  for (ELF::Section& section : binary->sections()) {
+    sections.push_back(&section);
+  }
+
+  for (ELF::Section* section : sections) {
+    binary->remove(*section, false);
+  }
+
+  std::vector<ELF::Segment*> segments;
+  for (ELF::Segment& segment : binary->segments()) {
+    segments.push_back(&segment);
+  }
+
+  for (ELF::Segment* segment : segments) {
+    binary->remove(*segment, false);
+  }
+
+  REQUIRE(recompute_extent(*binary) == 0);
+  append_and_check(*binary);
+}
+
+TEST_CASE("ELF append extent: PHDR relocation layouts",
+          "[lief][elf][append-extent]") {
+  SECTION("BINARY_END") {
+    std::unique_ptr<ELF::Binary> binary = parse_exec();
+    REQUIRE(binary->reserve_segments(32));
+
+    relocate_and_check(*binary, ELF::Binary::PHDR_RELOC::BINARY_END);
+  }
+
+  SECTION("SEGMENT_GAP") {
+    std::unique_ptr<ELF::Binary> binary = make_segment_gap_exec();
+    relocate_and_check(*binary, ELF::Binary::PHDR_RELOC::SEGMENT_GAP);
+  }
+
+  SECTION("BSS_END") {
+    std::unique_ptr<ELF::Binary> binary = parse_exec();
+    relocate_and_check(*binary, ELF::Binary::PHDR_RELOC::BSS_END);
+  }
+}
+


### PR DESCRIPTION
We have a use case for LIEF's ELF engine that involves appending a large number of segments to an ELF file. Adding a loaded section to an `ET_EXEC` binary also creates a segment. Several operations on this path previously performed linear searches over the binary layout or `DataHandler` nodes for each addition, causing the total cost to grow superlinearly as the number of sections and segments increased.

Profiling with `perf`, I optimized several sources of quadratic behavior, along with some significant linear-time costs.

### Performance

The benchmark repeatedly adds loaded sections to an ELF binary and serializes the result in memory with `Binary::raw()`.
The plots below compare the original and optimized implementations across small, medium, and large segment-count ranges (I'll provide any additional details if needed)
<p align="center">
<img width="32%" alt="Small benchmark comparison" src="https://github.com/user-attachments/assets/2630ca8e-251e-442a-ae4e-fab471b72782" />
<img width="32%" alt="Medium benchmark comparison" src="https://github.com/user-attachments/assets/5c77ea6b-a7b5-4ea8-902e-4ba98967bc4f" />
<img width="32%" alt="Large benchmark comparison" src="https://github.com/user-attachments/assets/a34338b5-2218-4d99-ab6d-cbde3bf9ef1e" />
</p>

While the primary target is workloads involving more than 10,000 segments, the changes also improve general case of 10-100 segments.

### Build
Built with
```
cmake -S . -B build
cd build
make
```