### PR TITLE
MachO: adjust __init_offsets when add_section shifts __TEXT

### DIFF
--- a/src/MachO/Binary.cpp
+++ b/src/MachO/Binary.cpp
@@ -1005,6 +1005,24 @@ ok_error_t Binary::shift(size_t value) {
       }
     }
   }
+  // The shift moved the code in __TEXT but not the image-base offsets in
+  // __TEXT,__init_offsets, so bump the ones past the shift point.
+  for (Section* section : sections_) {
+    if (section->type() != Section::TYPE::INIT_FUNC_OFFSETS) {
+      continue;
+    }
+    span<uint8_t> content = section->content();
+    for (size_t i = 0; i + sizeof(uint32_t) <= content.size();
+         i += sizeof(uint32_t)) {
+      uint32_t init_off = 0;
+      std::memcpy(&init_off, content.data() + i, sizeof(init_off));
+      if (init_off >= loadcommands_end) {
+        init_off += static_cast<uint32_t>(value);
+        std::memcpy(content.data() + i, &init_off, sizeof(init_off));
+      }
+    }
+  }
+
   refresh_seg_offset();
   available_command_space_ += value;
   return ok();


### PR DESCRIPTION
`add_section` into `__TEXT` shifts the following content via `Binary::shift`, but `shift` doesn't update the image-base offsets stored in `__TEXT,__init_offsets` (`S_INIT_FUNC_OFFSETS`). They keep pointing at the old location, so dyld jumps into the wrong place and the binary crashes at launch (SIGILL). The fix bumps each entry past the shift point.

```python
b = lief.MachO.parse("app").at(0)   # app has a constructor -> __init_offsets
b.add_section(lief.MachO.Section.create("__mysec", [0x41] * 0x4000))  # into __TEXT
b.write("out")   # SIGILLs on launch without the fix, runs with it
```

The constructor offset stays `0x4b0` while the code moves to `0x44b0`; a section too small to force a shift is unaffected. Verified on macOS arm64 and an iPhone Air (iOS 26.6). Closes #1229.
