### PR TITLE
Bound AArch64 epilog-scope allocation to prevent OOM on malformed exception data

### DIFF
--- a/include/LIEF/PE/Parser.hpp
+++ b/include/LIEF/PE/Parser.hpp
@@ -176,10 +176,27 @@ class LIEF_API Parser : public LIEF::Parser {
 
   std::unique_ptr<SpanStream> stream_from_rva(uint32_t rva, size_t size = 0);
 
+  bool consume_exception_scopes(size_t count) {
+    if (count > exception_scopes_budget_) {
+      exception_scopes_budget_ = 0;
+      return false;
+    }
+    exception_scopes_budget_ -= count;
+    return true;
+  }
+
   void record_relocation(uint32_t rva, span<const uint8_t> data);
   ok_error_t record_delta_relocation(uint32_t rva, int64_t delta, size_t size);
 
   private:
+  // Caps total AArch64 epilog scopes to bound allocations on a malformed table
+  void seed_exception_scopes_budget(size_t table_size) {
+    static constexpr size_t PDATA_ENTRY_SIZE = 2 * sizeof(uint32_t);
+    static constexpr size_t MAX_SCOPES_PER_FUNCTION = 32;
+    exception_scopes_budget_ = (table_size / PDATA_ENTRY_SIZE) *
+                               MAX_SCOPES_PER_FUNCTION;
+  }
+
   struct relocation_t {
     uint64_t size = 0;
     uint64_t value = 0;
@@ -273,6 +290,7 @@ class LIEF_API Parser : public LIEF::Parser {
   std::map<uint32_t, ExceptionInfo*> memoize_exception_info_;
   std::map<uint32_t, relocation_t> dyn_hdr_relocs_;
   std::vector<std::pair<ExceptionInfo*, uint32_t>> unresolved_chains_;
+  size_t exception_scopes_budget_ = 0;
   ParserConfig config_;
 };
 

--- a/src/PE/Parser.cpp
+++ b/src/PE/Parser.cpp
@@ -760,6 +760,8 @@ ok_error_t Parser::parse_exceptions() {
     return make_error_code(lief_errors::corrupted);
   }
 
+  seed_exception_scopes_budget(pdata.size());
+
   [[maybe_unused]] size_t idx = 0;
   while (*stream) {
     auto ptr = ExceptionInfo::parse(*this, *stream);
@@ -826,6 +828,8 @@ ok_error_t Parser::parse_chpe_exceptions() {
   }
 
   uint64_t base_offset = binary_->rva_to_offset(arm64->extra_rfe_table());
+
+  seed_exception_scopes_budget(arm64->extra_rfe_table_size());
 
   Header::MACHINE_TYPES target_arch = bin().header().machine();
   switch (target_arch) {

--- a/src/PE/exceptions_info/AArch64/UnpackedFunction.cpp
+++ b/src/PE/exceptions_info/AArch64/UnpackedFunction.cpp
@@ -19,6 +19,7 @@
 #include "LIEF/span.hpp"
 #include <sstream>
 
+#include "LIEF/PE/Parser.hpp"
 #include "LIEF/PE/exceptions_info/internal_arm64.hpp"
 #include "PE/exceptions_info/UnwindAArch64Decoder.hpp"
 
@@ -29,7 +30,7 @@ namespace LIEF::PE::unwind_aarch64 {
 
 using epilog_scope_t = UnpackedFunction::epilog_scope_t;
 
-std::unique_ptr<UnpackedFunction> UnpackedFunction::parse(Parser& /*ctx*/,
+std::unique_ptr<UnpackedFunction> UnpackedFunction::parse(Parser& ctx,
                                                           BinaryStream& strm,
                                                           uint32_t xdata_rva,
                                                           uint32_t rva) {
@@ -90,6 +91,11 @@ std::unique_ptr<UnpackedFunction> UnpackedFunction::parse(Parser& /*ctx*/,
   /// is required.
   std::vector<uint32_t> scopes;
   if (unpacked.E() == 0) {
+    if (!ctx.consume_exception_scopes(ecount)) {
+      LIEF_DEBUG("Epilog scope budget exhausted (record claims {} scopes)",
+                 ecount);
+      return func;
+    }
     func->epilog_scopes_offset_ = strm.pos() - strm_offset;
     if (!strm.read_objects(scopes, ecount)) {
       LIEF_DEBUG("Failed to read #{} epilog scopes", ecount);

--- a/src/PE/exceptions_info/RuntimeFunctionAArch64.cpp
+++ b/src/PE/exceptions_info/RuntimeFunctionAArch64.cpp
@@ -19,7 +19,7 @@
 #include "LIEF/PE/exceptions_info/internal_arm64.hpp"
 
 #include "LIEF/BinaryStream/BinaryStream.hpp"
-#include "LIEF/PE/Binary.hpp"
+#include "LIEF/BinaryStream/SpanStream.hpp"
 #include "LIEF/PE/Parser.hpp"
 
 #include "logging.hpp"
@@ -53,8 +53,7 @@ std::unique_ptr<RuntimeFunctionAArch64>
 
   if (flag == PACKED_FLAGS::UNPACKED) {
     uint32_t xdata_rva = details::xdata_unpacked_rva(*unwind_data);
-    uint32_t xdata_offset = ctx.bin().rva_to_offset(xdata_rva);
-    ScopedStream xdata_strm(ctx.stream(), xdata_offset);
+    std::unique_ptr<SpanStream> xdata_strm = ctx.stream_from_rva(xdata_rva);
     return unwind_aarch64::UnpackedFunction::parse(ctx, *xdata_strm, xdata_rva,
                                                    *rva_start);
   }

--- a/tests/pe/test_issues.py
+++ b/tests/pe/test_issues.py
@@ -1,3 +1,4 @@
+import struct
 import subprocess
 import sys
 from pathlib import Path
@@ -5,6 +6,81 @@ from textwrap import dedent
 
 import pytest
 from utils import address_space_limiter, get_sample
+
+
+def _aarch64_epilog_bomb(n_entries: int, section_pad: int) -> bytes:
+    """ARM64 PE whose n_entries .pdata records all point at one unwind record
+    claiming 65535 epilog scopes. section_pad=0 makes the scope array exactly
+    fill its section (tripping the per-section bound); slack lets it pass so only
+    the aggregate budget caps the total."""
+    file_align, sect_align = 0x200, 0x1000
+    align = lambda v, b: (v + b - 1) // b * b
+
+    headers = align(0x80 + 4 + 20 + 240 + 2 * 40, file_align)
+    # extended header (word1=0), E=0, epilog_count=0xFFFF
+    xdata = struct.pack("<II", 0, 0xFFFF) + b"\xAA" * (65535 * 4) + b"\x00" * section_pad
+    pdata_size = n_entries * 8
+    pdata_rva = sect_align
+    xdata_rva = pdata_rva + align(pdata_size, sect_align)
+    pdata = b"".join(struct.pack("<II", 0x1000 + i * 4, xdata_rva)
+                     for i in range(n_entries))
+
+    dos = b"MZ" + b"\x00" * 0x3A + struct.pack("<I", 0x80)
+    dos += b"\x00" * (0x80 - len(dos))
+    coff = struct.pack("<HHIIIHH", 0xAA64, 2, 0, 0, 0, 240, 0x0022)
+    opt = struct.pack("<HBBIIIIIQIIHHHHHHIIIIHHQQQQII",
+                      0x20B, 14, 0, 0, 0, 0, 0, 0, 0x140000000, sect_align,
+                      file_align, 6, 0, 0, 0, 6, 0, 0,
+                      xdata_rva + align(len(xdata), sect_align), headers, 0, 3, 0,
+                      0x100000, 0x1000, 0x100000, 0x1000, 0, 16)
+    dirs = [(0, 0)] * 16
+    dirs[3] = (pdata_rva, pdata_size)
+    opt += b"".join(struct.pack("<II", rva, size) for rva, size in dirs)
+
+    def section(name, rva, vsize, off, raw):
+        return name.ljust(8, b"\x00") + struct.pack(
+            "<IIIIIIHHI", vsize, rva, raw, off, 0, 0, 0, 0, 0x40000040)
+
+    pdata_off = headers
+    xdata_off = pdata_off + align(pdata_size, file_align)
+    sections = (section(b".pdata", pdata_rva, pdata_size, pdata_off,
+                        align(pdata_size, file_align)) +
+                section(b".rdata", xdata_rva, len(xdata), xdata_off,
+                        align(len(xdata), file_align)))
+
+    out = bytearray(dos + b"PE\x00\x00" + coff + opt + sections)
+    out += b"\x00" * (headers - len(out))
+    out += pdata.ljust(align(pdata_size, file_align), b"\x00")
+    out += xdata.ljust(align(len(xdata), file_align), b"\x00")
+    return bytes(out)
+
+
+@pytest.mark.parametrize("section_pad", [0, 0x20000],
+                         ids=["section_bound", "scope_budget"])
+def test_aarch64_epilog_scopes_dos(tmp_path, section_pad):
+    sample = tmp_path / "epilog_bomb.exe"
+    sample.write_bytes(_aarch64_epilog_bomb(20000, section_pad))
+
+    code = dedent("""\
+    import lief
+    import sys
+    lief.logging.disable()
+    config = lief.PE.ParserConfig()
+    config.parse_exceptions = True
+    pe = lief.PE.parse(sys.argv[1], config)
+    assert pe is not None
+    scopes = sum(len(e.epilog_scopes) for e in pe.exceptions
+                 if isinstance(e, lief.PE.unwind_aarch64.UnpackedFunction))
+    assert scopes < 1_000_000, scopes
+    print("OK")""")
+
+    stdout = subprocess.check_output(
+        [sys.executable, "-c", code, str(sample)],
+        timeout=60.0,
+        preexec_fn=address_space_limiter(),
+    )
+
+    assert b"OK" in stdout
 
 
 @pytest.mark.private


### PR DESCRIPTION
## Summary

Parsing an ARM64 PE with `parse_exceptions=True` can allocate gigabytes from a
tiny file. `UnpackedFunction::parse` reads an epilog-scope array whose count is a
16-bit file-controlled field, bounded only against the whole-file stream. Every
8-byte `.pdata` entry can point at a record claiming 65535 scopes (~512 KiB
each), so a **423 KB** file drives **10.6 GB** RSS (~64,000× amplification) —
an OOM/DoS on malformed input.

## Fix

1. Read scopes via `Parser::stream_from_rva()` so the count is bounded to the
   containing section (as the CHPE path already does).
2. Cap total scopes per exception table at 32 × function count — needed because
   MSVC folds `.xdata` into a large `.rdata`, defeating the section bound alone.

On overflow the record is kept scope-less and parsing continues (`DEBUG`-logged,
no crash). The spec allows 65535 scopes/function, so a per-record cap would clip
real binaries; the aggregate cap leaves 508 real ARM64 PEs (2.5M functions,
max 442/function) bit-identical.

## Test

`test_aarch64_epilog_scopes_dos` builds the PE in-process and parses it under a
2 GiB `RLIMIT_AS` (both bounds). Fails on `main`, passes here.