### PR TITLE
Avoid major/minor macro collisions in runtime version constructors

### DIFF
--- a/include/LIEF/runtime/osx/Host.hpp
+++ b/include/LIEF/runtime/osx/Host.hpp
@@ -31,9 +31,9 @@ class LIEF_API Host {
     uint32_t patch = 0;
 
     version_t(uint32_t major, uint32_t minor, uint32_t patch) :
-      major(major),
-      minor(minor),
-      patch(patch) {}
+      major{major},
+      minor{minor},
+      patch{patch} {}
 
     bool operator<=(const version_t& rhs) const;
     bool operator>(const version_t& rhs) const {

--- a/include/LIEF/runtime/windows/Host.hpp
+++ b/include/LIEF/runtime/windows/Host.hpp
@@ -34,9 +34,9 @@ class LIEF_API Host {
     version_t() = default;
 
     version_t(uint32_t major, uint32_t minor, uint32_t build_number) :
-      major(major),
-      minor(minor),
-      build_number(build_number) {}
+      major{major},
+      minor{minor},
+      build_number{build_number} {}
 
     bool operator<=(const version_t& rhs) const;
     bool operator>(const version_t& rhs) const {


### PR DESCRIPTION
**Why:** On glibc systems, `<sys/sysmacros.h>` defines function-like `major()` and `minor()` macros. The runtime host headers use `major(major)` and `minor(minor)` in constructor initializer lists, so the preprocessor rewrites the member names to `gnu_dev_major` and `gnu_dev_minor`. This currently breaks LIEF 1.0.0 builds in [conda-forge/lief-feedstock#74](https://github.com/conda-forge/lief-feedstock/pull/74).

**What:** Make the macOS and Windows runtime version constructors immune to the system `major()`/`minor()` macros without changing their API or stored values.

**How:**

- **Initializer syntax** — use brace initialization for the `major`, `minor`, and trailing version fields. Function-like macros are not invoked because the member tokens are no longer followed by `(`.
- **Scope** — change only the two affected inline constructors.

## Test Plan

```bash
c++ -std=c++17 -Iinclude -fsyntax-only /tmp/lief-version-macro-test.cpp
```
Run URL: local only (no run URL emitted)

The test translation unit includes `<sys/types.h>` and `<sys/sysmacros.h>` before both affected LIEF headers and constructs both version types. It reproduces the macro environment from the failing conda-forge builds.
