### PR TITLE
Require MbedTLS 4.0.0 exactly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if(NOT LIEF_OPT_MBEDTLS_EXTERNAL)
     -DTF_PSA_CRYPTO_USER_CONFIG_FILE="${CMAKE_CURRENT_SOURCE_DIR}/config/mbedtls/psa_config.h"
   )
 else()
-  find_package(MbedTLS 4.0.0 REQUIRED)
+  find_package(MbedTLS 4.0.0 EXACT REQUIRED)
   target_link_libraries(LIB_LIEF PRIVATE
                         MbedTLS::tfpsacrypto MbedTLS::mbedx509)
   if (LIEF_PYTHON_FREE_THREADED)

--- a/cmake/LIEFConfig.cmake.in
+++ b/cmake/LIEFConfig.cmake.in
@@ -82,7 +82,7 @@ macro(LIEF_load_targets lib_type)
     include(CMakeFindDependencyMacro)
 
     if(@LIEF_EXTERNAL_MBEDTLS@)
-      find_dependency(MbedTLS)
+      find_dependency(MbedTLS 4.0.0 EXACT)
     endif()
 
     if(@LIEF_EXTERNAL_UTF8CPP@)


### PR DESCRIPTION
## Summary

- require MbedTLS 4.0.0 exactly when `LIEF_OPT_MBEDTLS_EXTERNAL` is enabled
- propagate the same exact dependency through the installed LIEF CMake package

LIEF currently checks `MBEDTLS_VERSION_NUMBER == 0x04000000` and relies on MbedTLS 4.0 private PSA APIs, but `find_package(MbedTLS 4.0.0 REQUIRED)` also accepts later 4.x releases. This allowed MbedTLS 4.2.0 through configuration and then failed during compilation with the version assertion, changed private members, and a removed PSA header, as seen in the [conda-forge build](https://github.com/conda-forge/lief-feedstock/actions/runs/33276466411).

## Test plan

- Configure a minimal CMake consumer against MbedTLS 4.0.0: succeeds.
- Configure the same consumer against MbedTLS 4.2.0: rejected at `find_package` as not exactly 4.0.0.
- `git diff --check`
